### PR TITLE
docs: typo fix

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -74,7 +74,7 @@ export default defineConfig({
           text: 'Development',
           items: [
             { text: 'Repositories', link: '/learn/repos' },
-            { text: 'Governence', link: '/learn/governance' },
+            { text: 'Governance', link: '/learn/governance' },
             { text: 'FIPs', link: '/learn/fips' },
           ],
         },


### PR DESCRIPTION
Fixes the "Governance" spelling.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a typo in the navigation menu by changing "Governence" to "Governance".

### Detailed summary
- Fixed a typo in the navigation menu by changing "Governence" to "Governance".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->