### PR TITLE
docs: reorganize contract outlines

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -89,7 +89,7 @@ export default defineConfig({
             { text: 'Governance', link: '/learn/contributing/governance' },
             { text: 'FIPs', link: '/learn/contributing/fips' },
           ],
-        }
+        },
       ],
       '/developers/': [
         { text: 'Overview', link: '/developers/index' },

--- a/docs/reference/contracts/id-gateway.md
+++ b/docs/reference/contracts/id-gateway.md
@@ -1,38 +1,46 @@
+---
+outline: [2, 3]
+---
+
 # ID Gateway
 
-## price
+## Read
+
+### price
 
 Returns the price in wei to register an fid. This includes the price of 1 storage unit. To include additional storage units
 in the calculation, provide an optional `extraStorage` parameter.
 
-| Param Name   | type                 | Description                                                           |
+| Parameter    | type                 | Description                                                           |
 | ------------ | -------------------- | --------------------------------------------------------------------- |
 | extraStorage | `uint256` (optional) | The number of additional storage units to include in calculated price |
 
-## nonces
+### nonces
 
 Returns the next unused nonce for an address. Used for generating an EIP-712 [`Register`](#register-signature) signature for [registerFor](#registerfor).
 
-| Param Name | type      | Description                        |
-| ---------- | --------- | ---------------------------------- |
-| owner      | `address` | The address to query the nonce for |
+| Parameter | type      | Description                        |
+| --------- | --------- | ---------------------------------- |
+| owner     | `address` | The address to query the nonce for |
 
-## register
+## Write
+
+### register
 
 Register a new fid to the caller and pay for one or more units of storage. The caller must not already own an fid.
 
-| Param Name   | type                 | Description                                            |
+| Parameter    | type                 | Description                                            |
 | ------------ | -------------------- | ------------------------------------------------------ |
 |              | `wei` (payable)      | The payable amount to transfer to pay for registration |
 | recovery     | `address`            | The recovery address for the newly registered fid      |
 | extraStorage | `uint256` (optional) | The number of additional storage units to rent         |
 
-## registerFor
+### registerFor
 
 Register a new fid to a specific address and pay for one or more units of storage. The receiving
 address must sign an EIP-712 [`Register`](#register-signature) message approving the registration. the receiver must not already own an fid.
 
-| Param Name   | type                 | Description                                            |
+| Parameter    | type                 | Description                                            |
 | ------------ | -------------------- | ------------------------------------------------------ |
 |              | `wei` (payable)      | The payable amount to transfer to pay for registration |
 | to           | `address`            | The address to register the fid to                     |
@@ -41,18 +49,18 @@ address must sign an EIP-712 [`Register`](#register-signature) message approving
 | sig          | `bytes`              | EIP-712 `Register` signature from the `to` address     |
 | extraStorage | `uint256` (optional) | The number of additional storage units to rent         |
 
-### Register signature
+#### Register signature
 
 To register an fid on behalf of another account, you must provide an EIP-712 typed signature from the receiving address in the following format:
 
 `Register(address to,address recovery,uint256 nonce,uint256 deadline)`
 
-| Param Name | type      | Description                                                                           |
-| ---------- | --------- | ------------------------------------------------------------------------------------- |
-| to         | `address` | The address to register the fid to. The typed message must be signed by this address. |
-| recovery   | `address` | The recovery address for the newly registered fid                                     |
-| nonce      | `uint256` | Current nonce of the `to` address                                                     |
-| deadline   | `uint256` | Expiration timestamp of the signature                                                 |
+| Parameter | type      | Description                                                                           |
+| --------- | --------- | ------------------------------------------------------------------------------------- |
+| to        | `address` | The address to register the fid to. The typed message must be signed by this address. |
+| recovery  | `address` | The recovery address for the newly registered fid                                     |
+| nonce     | `uint256` | Current nonce of the `to` address                                                     |
+| deadline  | `uint256` | Expiration timestamp of the signature                                                 |
 
 ::: code-group
 

--- a/docs/reference/contracts/id-registry.md
+++ b/docs/reference/contracts/id-registry.md
@@ -1,90 +1,98 @@
+---
+outline: [2, 3]
+---
+
 # ID Registry
 
-## idOf
+## Read
+
+### idOf
 
 Returns the fid (`uint256`) of an address, or zero if the address does not own an fid.
 
-| Param Name | type      | Description                      |
-| ---------- | --------- | -------------------------------- |
-| owner      | `address` | The address to query the fid for |
+| Parameter | type      | Description                      |
+| --------- | --------- | -------------------------------- |
+| owner     | `address` | The address to query the fid for |
 
-## custodyOf
+### custodyOf
 
 Returns the custody address (`address`) that owns an fid. Returns the zero address if the fid does not exist.
 
-| Param Name | type      | Description                    |
-| ---------- | --------- | ------------------------------ |
-| fid        | `uint256` | The fid to query the owner for |
+| Parameter | type      | Description                    |
+| --------- | --------- | ------------------------------ |
+| fid       | `uint256` | The fid to query the owner for |
 
-## recoveryOf
+### recoveryOf
 
 Returns the recovery address (`address`) of an fid. Returns the zero address if the fid does not exist.
 
-| Param Name | type      | Description                               |
-| ---------- | --------- | ----------------------------------------- |
-| fid        | `uint256` | The fid to query the recovery address for |
+| Parameter | type      | Description                               |
+| --------- | --------- | ----------------------------------------- |
+| fid       | `uint256` | The fid to query the recovery address for |
 
-## idCounter
+### idCounter
 
 Returns the current highest fid (`uint256`) that has been registered.
 
-## verifyFidSignature
+### verifyFidSignature
 
 Verify that a signature was produced by the custody address that currently owns an fid. Returns a `bool`.
 
-| Param Name     | type      | Description                           |
+| Parameter      | type      | Description                           |
 | -------------- | --------- | ------------------------------------- |
 | custodyAddress | `address` | The address to check the signature of |
 | fid            | `uint256` | The fid to check the signature of     |
 | digest         | `bytes32` | The hashed data that was signed       |
 | sig            | `bytes`   | The provided signature                |
 
-## nonces
+### nonces
 
-Returns the next unused nonce for an address. Used for generating EIP-712 signatures.
+Returns the next unused nonce (`uint256`) for an address. Used for generating EIP-712 signatures.
 
-| Param Name | type      | Description                        |
-| ---------- | --------- | ---------------------------------- |
-| owner      | `address` | The address to query the nonce for |
+| Parameter | type      | Description                        |
+| --------- | --------- | ---------------------------------- |
+| owner     | `address` | The address to query the nonce for |
 
-## register
+## Write
+
+### register
 
 Will revert if called directly, must be called via the [ID Gateway](/reference/contracts/id-gateway.md).
 
-## changeRecoveryAddress
+### changeRecoveryAddress
 
 Change the recovery address of the caller's fid to a new address.
 
-| Param Name | type      | Description              |
-| ---------- | --------- | ------------------------ |
-| recovery   | `address` | The new recovery address |
+| Parameter | type      | Description              |
+| --------- | --------- | ------------------------ |
+| recovery  | `address` | The new recovery address |
 
-## transfer
+### transfer
 
 Transfer the fid of the caller to a new address. The receiving address must sign an EIP-712 [`Transfer`](#transfer-signature) message accepting the transfer. The `to` address must not already own an fid.
 
-| Param Name | type      | Description                                                               |
-| ---------- | --------- | ------------------------------------------------------------------------- |
-| to         | `address` | The address to transfer the fid to                                        |
-| deadline   | `uint256` | The deadline for the signature                                            |
-| sig        | `bytes`   | EIP-712 [`Transfer`](#transfer-signature) signature from the `to` address |
+| Parameter | type      | Description                                                               |
+| --------- | --------- | ------------------------------------------------------------------------- |
+| to        | `address` | The address to transfer the fid to                                        |
+| deadline  | `uint256` | The deadline for the signature                                            |
+| sig       | `bytes`   | EIP-712 [`Transfer`](#transfer-signature) signature from the `to` address |
 
 ::: warning
 Transferring an fid does not reset its recovery address. To transfer an fid and update its recovery address, call [`transferAndChangeRecovery`](#transferandchangerecovery). If you are receiving an fid from an untrusted sender, ensure its recovery address is cleared or changed on transfer.
 :::
 
-### Transfer signature
+#### Transfer signature
 
 To transfer an fid to another account, you must provide an EIP-712 typed signature from the receiving address in the following format:
 
 `Transfer(uint256 fid,address to,uint256 nonce,uint256 deadline)`
 
-| Param Name | type      | Description                           |
-| ---------- | --------- | ------------------------------------- |
-| fid        | `uint256` | The fid being transferred             |
-| to         | `address` | The address receiving the fid.        |
-| nonce      | `uint256` | Current nonce of the signer address   |
-| deadline   | `uint256` | Expiration timestamp of the signature |
+| Parameter | type      | Description                           |
+| --------- | --------- | ------------------------------------- |
+| fid       | `uint256` | The fid being transferred             |
+| to        | `address` | The address receiving the fid.        |
+| nonce     | `uint256` | Current nonce of the signer address   |
+| deadline  | `uint256` | Expiration timestamp of the signature |
 
 ::: code-group
 
@@ -150,45 +158,32 @@ export const readNonce = async () => {
 
 :::
 
-## transferFor
-
-Transfer the fid owned by the `from` address to the `to` address. The caller must provide two EIP-712 [`Transfer`](#transfer-signature) signatures: one from the `from` address authorizing the transfer out and one from the `to` address accepting the transfer in. These messages have the same format. The `to` address must not already own an fid.
-
-| Param Name   | type      | Description                                                                 |
-| ------------ | --------- | --------------------------------------------------------------------------- |
-| from         | `address` | The address to transfer the fid from                                        |
-| to           | `address` | The address to transfer the fid to                                          |
-| fromDeadline | `uint256` | The deadline for the signature                                              |
-| fromSig      | `bytes`   | EIP-712 [`Transfer`](#transfer-signature) signature from the `from` address |
-| toDeadline   | `uint256` | The deadline for the signature                                              |
-| toSig        | `bytes`   | EIP-712 [`Transfer`](#transfer-signature) signature from the `to` address   |
-
-## transferAndChangeRecovery
+### transferAndChangeRecovery
 
 Transfer the fid of the caller to a new address, and change the fid's recovery address. This can be used to safely receive an fid transfer from an untrusted address.
 
 The receiving address must sign an EIP-712 [`TransferAndChangeRecovery`](#transferandchangerecovery-signature) message accepting the transfer. The `to` address must not already own an fid.
 
-| Param Name | type      | Description                                                                                       |
-| ---------- | --------- | ------------------------------------------------------------------------------------------------- |
-| to         | `address` | The address to transfer the fid to                                                                |
-| recovery   | `address` | The new recovery address                                                                          |
-| deadline   | `uint256` | The deadline for the signature                                                                    |
-| sig        | `bytes`   | EIP-712 [`TransferAndChangeRecovery`](#transferandchangerecovery) signature from the `to` address |
+| Parameter | type      | Description                                                                                       |
+| --------- | --------- | ------------------------------------------------------------------------------------------------- |
+| to        | `address` | The address to transfer the fid to                                                                |
+| recovery  | `address` | The new recovery address                                                                          |
+| deadline  | `uint256` | The deadline for the signature                                                                    |
+| sig       | `bytes`   | EIP-712 [`TransferAndChangeRecovery`](#transferandchangerecovery) signature from the `to` address |
 
-### TransferAndChangeRecovery signature
+#### TransferAndChangeRecovery signature
 
 To transfer an fid to another account and change recovery, you must provide an EIP-712 typed signature from the `to` address in the following format:
 
 `TransferAndChangeRecovery(uint256 fid,address to,address recovery,uint256 nonce,uint256 deadline)`
 
-| Param Name | type      | Description                           |
-| ---------- | --------- | ------------------------------------- |
-| fid        | `uint256` | The fid being transferred             |
-| to         | `address` | The address receiving the fid         |
-| recovery   | `address` | The new recovery address              |
-| nonce      | `uint256` | Current nonce of the signer address   |
-| deadline   | `uint256` | Expiration timestamp of the signature |
+| Parameter | type      | Description                           |
+| --------- | --------- | ------------------------------------- |
+| fid       | `uint256` | The fid being transferred             |
+| to        | `address` | The address receiving the fid         |
+| recovery  | `address` | The new recovery address              |
+| nonce     | `uint256` | Current nonce of the signer address   |
+| deadline  | `uint256` | Expiration timestamp of the signature |
 
 ::: code-group
 
@@ -256,13 +251,128 @@ export const readNonce = async () => {
 
 :::
 
-## transferAndChangeRecoveryFor
+### recover
+
+Transfer a fid to a new address if caller is the recovery address for that fid. The receiving address must sign an EIP-712 [`Transfer`](#transfer-signature) message accepting the transfer.
+
+The `to` address must not already own an fid.
+
+| Parameter | type      | Description                                                               |
+| --------- | --------- | ------------------------------------------------------------------------- |
+| from      | `address` | The address to transfer the fid from                                      |
+| to        | `address` | The address to transfer the fid to                                        |
+| deadline  | `uint256` | The deadline for the signature                                            |
+| sig       | `bytes`   | EIP-712 [`Transfer`](#transfer-signature) signature from the `to` address |
+
+### changeRecoveryAddressFor
+
+Change the recovery address of an fid on behalf of the owner by providing a signature. The owner of the fid must sign an EIP-712 `ChangeRecoveryAddress` signature approving the change.
+
+| Parameter | type      | Description                                                                            |
+| --------- | --------- | -------------------------------------------------------------------------------------- |
+| owner     | `address` | Address of the fid owner                                                               |
+| recovery  | `address` | The new recovery address                                                               |
+| deadline  | `uint256` | The deadline for the signature                                                         |
+| sig       | `bytes`   | EIP-712 [`ChangeRecoveryAddress`](#transfer-signature) signature from the `to` address |
+
+### ChangeRecoveryAddress signature
+
+To change a recovery address on behalf of an fid owner, you must provide an EIP-712 typed signature from the `owner` address in the following format:
+
+`ChangeRecoveryAddress(uint256 fid,address from,address to,uint256 nonce,uint256 deadline)`
+
+| Parameter | type      | Description                           |
+| --------- | --------- | ------------------------------------- |
+| fid       | `uint256` | The owner's fid                       |
+| from      | `address` | The previous recovery address         |
+| to        | `address` | The new recovery address              |
+| nonce     | `uint256` | Current nonce of the signer address   |
+| deadline  | `uint256` | Expiration timestamp of the signature |
+
+```ts [@farcaster/hub-web]
+import { ViemWalletEip712Signer } from '@farcaster/hub-web';
+import { walletClient, account } from './clients.ts';
+import { readNonce, getDeadline } from './helpers.ts';
+
+const nonce = await readNonce();
+const deadline = getDeadline();
+
+const eip712Signer = new ViemWalletEip712Signer(walletClient);
+const signature = await eip712signer.signChangeRecoveryAddress({
+  fid: 1n,
+  from: '0x00000000FcB080a4D6c39a9354dA9EB9bC104cd7',
+  to: '0xD7029BDEa1c17493893AAfE29AAD69EF892B8ff2',
+  nonce,
+  deadline,
+});
+```
+
+```ts [Viem]
+import { ID_REGISTRY_EIP_712_TYPES } from '@farcaster/hub-web';
+import { walletClient, account } from './clients.ts';
+import { readNonce, getDeadline } from './helpers.ts';
+
+const nonce = await readNonce();
+const deadline = getDeadline();
+
+const signature = await walletClient.signTypedData({
+  account,
+  ...ID_REGISTRY_EIP_712_TYPES,
+  primaryType: 'ChangeRecoveryAddress',
+  message: {
+    fid: 1n,
+    from: '0x00000000FcB080a4D6c39a9354dA9EB9bC104cd7',
+    to: '0xD7029BDEa1c17493893AAfE29AAD69EF892B8ff2',
+    nonce,
+    deadline,
+  },
+});
+```
+
+```ts [helpers.ts]
+import { ID_REGISTRY_ADDRESS, idGatewayABI } from '@farcaster/hub-web';
+import { publicClient, account } from './clients.ts';
+
+export const getDeadline = () => {
+  const now = Math.floor(Date.now() / 1000);
+  const oneHour = 60 * 60;
+  return now + oneHour;
+};
+
+export const readNonce = async () => {
+  return await publicClient.readContract({
+    address: ID_REGISTRY_ADDRESS,
+    abi: idRegistryABI,
+    functionName: 'nonce',
+    args: [account],
+  });
+};
+```
+
+<<< @/examples/contracts/clients.ts
+
+:::
+
+### transferFor
+
+Transfer the fid owned by the `from` address to the `to` address. The caller must provide two EIP-712 [`Transfer`](#transfer-signature) signatures: one from the `from` address authorizing the transfer out and one from the `to` address accepting the transfer in. These messages have the same format. The `to` address must not already own an fid.
+
+| Parameter    | type      | Description                                                                 |
+| ------------ | --------- | --------------------------------------------------------------------------- |
+| from         | `address` | The address to transfer the fid from                                        |
+| to           | `address` | The address to transfer the fid to                                          |
+| fromDeadline | `uint256` | The deadline for the signature                                              |
+| fromSig      | `bytes`   | EIP-712 [`Transfer`](#transfer-signature) signature from the `from` address |
+| toDeadline   | `uint256` | The deadline for the signature                                              |
+| toSig        | `bytes`   | EIP-712 [`Transfer`](#transfer-signature) signature from the `to` address   |
+
+### transferAndChangeRecoveryFor
 
 Transfer the fid owned by the `from` address to the `to` address, and change the fid's recovery address. This can be used to safely receive an fid transfer from an untrusted address.
 
 The caller must provide two EIP-712 [`TransferAndChangeRecovery`](#transferandchangerecovery-signature) signatures: one from the `from` address authorizing the transfer out and one from the `to` address accepting the transfer in. These messages have the same format. The `to` address must not already own an fid.
 
-| Param Name   | type      | Description                                                                                                   |
+| Parameter    | type      | Description                                                                                                   |
 | ------------ | --------- | ------------------------------------------------------------------------------------------------------------- |
 | from         | `address` | The address to transfer the fid from                                                                          |
 | to           | `address` | The address to transfer the fid to                                                                            |
@@ -271,26 +381,13 @@ The caller must provide two EIP-712 [`TransferAndChangeRecovery`](#transferandch
 | toDeadline   | `uint256` | The deadline for the signature                                                                                |
 | toSig        | `bytes`   | EIP-712 [`TransferAndChangeRecovery`](#transferandchangerecovery-signature) signature from the `to` address   |
 
-## recover
-
-Transfer a fid to a new address if caller is the recovery address for that fid. The receiving address must sign an EIP-712 [`Transfer`](#transfer-signature) message accepting the transfer.
-
-The `to` address must not already own an fid.
-
-| Param Name | type      | Description                                                               |
-| ---------- | --------- | ------------------------------------------------------------------------- |
-| from       | `address` | The address to transfer the fid from                                      |
-| to         | `address` | The address to transfer the fid to                                        |
-| deadline   | `uint256` | The deadline for the signature                                            |
-| sig        | `bytes`   | EIP-712 [`Transfer`](#transfer-signature) signature from the `to` address |
-
-## recoverFor
+### recoverFor
 
 Transfer an fid to a new address with a signature from the fid's recovery address. The caller must provide two EIP-712 [`Transfer`](#transfer-signature) signatures: one from the recovery address authorizing the transfer out and one from the `to` address accepting the transfer in. These messages have the same format.
 
 The `to` address must not already own an fid.
 
-| Param Name       | type      | Description                                                                   |
+| Parameter        | type      | Description                                                                   |
 | ---------------- | --------- | ----------------------------------------------------------------------------- |
 | from             | `address` | The address to transfer the fid from                                          |
 | to               | `address` | The address to transfer the fid to                                            |

--- a/docs/reference/contracts/key-gateway.md
+++ b/docs/reference/contracts/key-gateway.md
@@ -1,29 +1,37 @@
+---
+outline: [2, 3]
+---
+
 # Key Gateway
 
-## nonces
+## Read
+
+### nonces
 
 Returns the next unused nonce for an address. Used for generating EIP-712 signatures in [addFor](#addFor).
 
-| Param Name | type      | Description                        |
-| ---------- | --------- | ---------------------------------- |
-| owner      | `address` | The address to query the nonce for |
+| Parameter | type      | Description                        |
+| --------- | --------- | ---------------------------------- |
+| owner     | `address` | The address to query the nonce for |
 
-## add
+## Write
+
+### add
 
 Add a key for the caller's fid. Sets the key state to `Added`. Reverts if the key is already registered for the caller's fid.
 
-| Param Name   | type         | Description                                              |
+| Parameter    | type         | Description                                              |
 | ------------ | ------------ | -------------------------------------------------------- |
 | keyType      | `uint32` (1) | Must be set to 1, only key type supported currently      |
 | key          | `bytes`      | Bytes of the public key to add                           |
 | metadataType | `uint8` (1)  | Must be set to 1, only metadata type supported currently |
 | metadata     | `bytes`      | Signed key metadata                                      |
 
-## addFor
+### addFor
 
 Add a key on behalf of another fid owner by providing a signature. The owner of the fid must sign an EIP-712 `Add` message approving the key. Reverts if the key is already registered for the owner's fid.
 
-| Param Name   | type         | Description                                              |
+| Parameter    | type         | Description                                              |
 | ------------ | ------------ | -------------------------------------------------------- |
 | fidOwner     | `address`    | The address that owns the fid to add the key to          |
 | keyType      | `uint32` (1) | Must be set to 1, only key type supported currently      |
@@ -33,13 +41,13 @@ Add a key on behalf of another fid owner by providing a signature. The owner of 
 | deadline     | `uint256`    | Expiration timestamp of the signature                    |
 | sig          | `bytes`      | EIP-712 signature from `fidOwner`                        |
 
-### Add signature
+#### Add signature
 
 To add a key on behalf of another account, you must provide an EIP-712 typed signature from the account in the following format:
 
 `Add(address owner,uint32 keyType,bytes key,uint8 metadataType,bytes metadata,uint256 nonce,uint256 deadline)`
 
-| Param Name   | type         | Description                                                                                        |
+| Parameter    | type         | Description                                                                                        |
 | ------------ | ------------ | -------------------------------------------------------------------------------------------------- |
 | owner        | `address`    | The address that owns the fid to add the key to. The typed message must be signed by this address. |
 | keyType      | `uint32` (1) | Must be set to 1, only key type supported currently                                                |

--- a/docs/reference/contracts/key-registry.md
+++ b/docs/reference/contracts/key-registry.md
@@ -1,83 +1,91 @@
+---
+outline: [2, 3]
+---
+
 # Key Registry API
 
-## totalKeys
+## Read
+
+### totalKeys
 
 Returns the number of active keys (`uint256`) for an fid.
 
-| Param Name | type                                 | Description                         |
-| ---------- | ------------------------------------ | ----------------------------------- |
-| fid        | `uint256`                            | fid to query for                    |
-| state      | `uint8` (1 for Added, 2 for Removed) | State of the key (added or removed) |
+| Parameter | type                                 | Description                         |
+| --------- | ------------------------------------ | ----------------------------------- |
+| fid       | `uint256`                            | fid to query for                    |
+| state     | `uint8` (1 for Added, 2 for Removed) | State of the key (added or removed) |
 
-## keysOf
+### keysOf
 
 Returns an array of public keys (`bytes[]`) for an fid.
 
-| Param Name | type                                 | Description                         |
-| ---------- | ------------------------------------ | ----------------------------------- |
-| fid        | `uint256`                            | fid to query for                    |
-| state      | `uint8` (1 for Added, 2 for Removed) | State of the key (added or removed) |
-| startIdx   | `uint256` (optional)                 | Start index for pagination          |
-| batchSize  | `uint256` (optional)                 | Batch size for pagination           |
+| Parameter | type                                 | Description                         |
+| --------- | ------------------------------------ | ----------------------------------- |
+| fid       | `uint256`                            | fid to query for                    |
+| state     | `uint8` (1 for Added, 2 for Removed) | State of the key (added or removed) |
+| startIdx  | `uint256` (optional)                 | Start index for pagination          |
+| batchSize | `uint256` (optional)                 | Batch size for pagination           |
 
 ::: warning
 Don't call this onchain! This function is very expensive for users with many keys, since it copies the entire key set to memory. It's meant to be called by offchain tools, not by other contracts.
 :::
 
-## keyDataOf
+### keyDataOf
 
 Returns the state (`uint8`) and keyType (`uint32`) of particular key for an fid.
 
-| Param Name | type      | Description                       |
-| ---------- | --------- | --------------------------------- |
-| fid        | `uint256` | fid to query for                  |
-| key        | `bytes`   | public key registered for the fid |
+| Parameter | type      | Description                       |
+| --------- | --------- | --------------------------------- |
+| fid       | `uint256` | fid to query for                  |
+| key       | `bytes`   | public key registered for the fid |
 
-## add
+## Write
+
+### add
 
 Will revert if called directly, must be called via the [Key Gateway](/reference/contracts/key-gateway.md)
 
-## remove
+### remove
 
 Removes a key from the caller's fid. Sets the key state to `Removed`.
 
-| Param Name | type    | Description          |
-| ---------- | ------- | -------------------- |
-| key        | `bytes` | public key to remove |
+| Parameter | type    | Description          |
+| --------- | ------- | -------------------- |
+| key       | `bytes` | public key to remove |
 
 ::: warning
 Removing a signer key will delete all offchain messages associated with the signer from Hubs.
 :::
 
-## removeFor
+### removeFor
 
 Remove a key on behalf of another fid owner by providing a signature. The owner of the fid must sign an EIP-712 `Remove` message approving the removal. Reverts if the key does not exist or is already removed for the owner's fid.
 
 Removing a signer key will delete all messages associated with the signer.
 
-| Param Name | type      | Description                                     |
-| ---------- | --------- | ----------------------------------------------- |
-| fidOwner   | `address` | address that owns the fid                       |
-| key        | `bytes`   | public key to remove (must be owned by the fid) |
-| deadline   | `uint256` | deadline for the signature                      |
-| sig        | `bytes`   | EIP-712 signature from the `fidOwner` address   |
+| Parameter | type      | Description                                     |
+| --------- | --------- | ----------------------------------------------- |
+| fidOwner  | `address` | address that owns the fid                       |
+| key       | `bytes`   | public key to remove (must be owned by the fid) |
+| deadline  | `uint256` | deadline for the signature                      |
+| sig       | `bytes`   | EIP-712 signature from the `fidOwner` address   |
 
 ::: warning
 Removing a signer key will delete all offchain messages associated with the signer from Hubs.
 :::
 
-### Remove signature
+#### Remove signature
 
 To remove a key on behalf of another account, you must provide an EIP-712 typed signature from the account in the following format:
 
 `Remove(address owner,bytes key,uint256 nonce,uint256 deadline)`
 
-| Param Name | type      | Description                                                                                             |
-| ---------- | --------- | ------------------------------------------------------------------------------------------------------- |
-| owner      | `address` | The address that owns the fid to remove the key from. The typed message must be signed by this address. |
-| key        | `bytes`   | Bytes of the public key to remove                                                                       |
-| nonce      | `uint256` | Current nonce of the `owner` address                                                                    |
-| deadline   | `uint256` | Expiration timestamp of the signature                                                                   |
+| Parameter | type      | Description                                                                                             |
+| --------- | --------- | ------------------------------------------------------------------------------------------------------- |
+| owner     | `address` | The address that owns the fid to remove the key from. The typed message must be signed by this address. |
+| key       | `bytes`   | Bytes of the public key to remove                                                                       |
+| nonce     | `uint256` | Current nonce of the `owner` address                                                                    |
+| deadline  | `uint256` | Expiration timestamp of the signature                                                                   |
 
 ::: code-group
 
@@ -154,7 +162,7 @@ export const readNonce = async () => {
 
 | Error            | Selector   | Description                                                                                                                                                                      |
 | ---------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ExceedsMaximum   | `29264042` | Adding the key would exceed the maximum number of keys per fid (1000)                                                                                                            |
+| ExceedsMaximum   | `29264042` | Adding the key would exceed the maximum number of keys per fid (currently 1000)                                                                                                  |
 | InvalidSignature | `8baa579f` | The provided signature is invalid. It may be incorrectly formatted, or signed by the wrong address.                                                                              |
 | InvalidState     | `baf3f0f7` | The call would violate the state transition rules of the KeyRegistry. (Adding a key that already exists, removing a key that does not exist, adding a key that has been removed) |
 | SignatureExpired | `0819bdcd` | The provided signature has expired. Collect a new signature from the signer with a later deadline timestamp.                                                                     |

--- a/docs/reference/contracts/storage-registry.md
+++ b/docs/reference/contracts/storage-registry.md
@@ -1,10 +1,16 @@
+---
+outline: [2, 3]
+---
+
 # Storage Registry
 
-## unitPrice
+## Read
+
+### unitPrice
 
 Returns the price in wei (`uint256`) to register 1 unit of storage.
 
-## price
+### price
 
 Returns the price in wei (`uint256`) to register the given number of units of storage.
 
@@ -12,7 +18,9 @@ Returns the price in wei (`uint256`) to register the given number of units of st
 | ------------ | -------------------- | ---------------------------------------------------------------- |
 | extraStorage | `uint256` (optional) | The number of additional storage units to include in final price |
 
-## rent
+## Write
+
+### rent
 
 Rents the specified number of storage units for the given fid. Excess ether will be returned to the sender. The units are valid
 for 1 year from the time of registration.
@@ -23,7 +31,7 @@ for 1 year from the time of registration.
 | fid        | `uint256`       | The fid to credit the storage units to            |
 | units      | `uint256`       | The number of units of storage to purchase        |
 
-## batchRent
+### batchRent
 
 Rent storage for multiple fids in a single call. The caller must provide at least price(units) wei of payment where units is the sum of storage units requested across all fids. Excess ether will be returned to the sender. The units are valid for 1 year from the time of registration.
 


### PR DESCRIPTION
- Reorganize contract pages into Read/Write sections.
- Use `outline:` frontmatter YAML to configure contract page outlines.
- Add missing `changeRecoveryAddressFor` section.