### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/developers/guides/advanced/transfer-fid.md
+++ b/docs/developers/guides/advanced/transfer-fid.md
@@ -23,7 +23,7 @@ const signature = await eip712signer.signTransfer({
 
 const { request: transferRequest } = await walletClient.simulateContract({
   ...IdContract,
-  functionName: "transfer",
+  functionName: 'transfer',
   args: [account, deadline, signature], // to, deadline, signature
 });
 
@@ -76,5 +76,5 @@ export const readNonce = async () => {
 
 :::
 
-See the [ID Registry](/reference/contracts/id-registry#transfer) section for more
+See the [ID Registry](/reference/contracts/reference/id-registry#transfer) section for more
 details.


### PR DESCRIPTION
Fix broken link from "Transfer fid" example page.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

This PR focuses on updating the link to the ID Registry section in the `transfer-fid.md` file. The notable changes include:

- Changed the value of `functionName` from "transfer" to 'transfer'
- Updated the link to the ID Registry section

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->