### PR TITLE
fix: s/nonce/nonces

### DIFF
--- a/docs/reference/contracts/reference/id-gateway.md
+++ b/docs/reference/contracts/reference/id-gateway.md
@@ -119,7 +119,7 @@ export const readNonce = async () => {
   return await publicClient.readContract({
     address: ID_GATEWAY_ADDRESS,
     abi: idGatewayABI,
-    functionName: 'nonce',
+    functionName: 'nonces',
     args: [account],
   });
 };

--- a/docs/reference/contracts/reference/id-registry.md
+++ b/docs/reference/contracts/reference/id-registry.md
@@ -349,7 +349,7 @@ export const readNonce = async () => {
   return await publicClient.readContract({
     address: ID_REGISTRY_ADDRESS,
     abi: idRegistryABI,
-    functionName: 'nonce',
+    functionName: 'nonces',
     args: [account],
   });
 };

--- a/docs/reference/contracts/reference/key-gateway.md
+++ b/docs/reference/contracts/reference/key-gateway.md
@@ -129,7 +129,7 @@ export const readNonce = async () => {
   return await publicClient.readContract({
     address: KEY_GATEWAY_ADDRESS,
     abi: keyGatewayABI,
-    functionName: 'nonce',
+    functionName: 'nonces',
     args: [account],
   });
 };

--- a/docs/reference/contracts/reference/key-registry.md
+++ b/docs/reference/contracts/reference/key-registry.md
@@ -150,7 +150,7 @@ export const readNonce = async () => {
   return await publicClient.readContract({
     address: KEY_REGISTRY_ADDRESS,
     abi: keyRegistryABI,
-    functionName: 'nonce',
+    functionName: 'nonces',
     args: [account],
   });
 };


### PR DESCRIPTION
Correct name of "read nonce" function.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on changing the function name from 'nonce' to 'nonces' in multiple contract reference files.

### Detailed summary:
- In `id-gateway.md`, changed the function name from 'nonce' to 'nonces'.
- In `id-registry.md`, changed the function name from 'nonce' to 'nonces'.
- In `key-gateway.md`, changed the function name from 'nonce' to 'nonces'.
- In `key-registry.md`, changed the function name from 'nonce' to 'nonces'.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->