### PR TITLE
docs: remove .html suffix

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     ],
     ['meta', { name: 'twitter:site', content: '@farcaster_xyz' }],
   ],
+  cleanUrls: true,
   themeConfig: {
     nav: [
       { text: 'Learn', link: '/learn/what-is-farcaster/overview', activeMatch: '/learn/' },

--- a/docs/developers/guides/advanced/add-signer.md
+++ b/docs/developers/guides/advanced/add-signer.md
@@ -11,11 +11,11 @@
 To add a signer key to a user's fid, you'll need to follow six steps:
 
 1. Set up [Viem](https://viem.sh/) clients and [`@farcaster/hub-web`](https://www.npmjs.com/package/@farcaster/hub-web) signers.
-2. Register an [app fid](/reference/contracts/faq.html#what-is-an-app-fid-how-do-i-get-one) if your app does not already have one.
+2. Register an [app fid](/reference/contracts/faq#what-is-an-app-fid-how-do-i-get-one) if your app does not already have one.
 3. Create a new signer keypair for the user.
-4. Use your app account to create a [Signed Key Request](/reference/contracts/reference/signed-key-request-validator.html).
-5. Collect an [`Add`](/reference/contracts/reference/key-gateway.html#add-signature) signature from the user.
-6. Call the [Key Gateway](https://docs.farcaster.xyz/reference/contracts/reference/key-gateway.html#addFor) contract to add the key onchain.
+4. Use your app account to create a [Signed Key Request](/reference/contracts/reference/signed-key-request-validator).
+5. Collect an [`Add`](/reference/contracts/reference/key-gateway#add-signature) signature from the user.
+6. Call the [Key Gateway](https://docs.farcaster.xyz/reference/contracts/reference/key-gateway#addFor) contract to add the key onchain.
 
 ### 1. Set up clients and signers
 

--- a/docs/developers/guides/advanced/decode-key-metadata.md
+++ b/docs/developers/guides/advanced/decode-key-metadata.md
@@ -1,6 +1,6 @@
 # Decode key metadata
 
-When users add a new key to the Key Registry, the contract emits [encoded metadata](/reference/contracts/reference/signed-key-request-validator.html#signedkeyrequestmetadata-struct) in an event. You can use this metadata to determine who requested the key.
+When users add a new key to the Key Registry, the contract emits [encoded metadata](/reference/contracts/reference/signed-key-request-validator#signedkeyrequestmetadata-struct) in an event. You can use this metadata to determine who requested the key.
 
 To decode key metadata, you can use Viem's `decodeAbiParameters` function:
 
@@ -63,5 +63,5 @@ console.log(decoded);
 
 :::
 
-See the [Signed Key Request Validator](/reference/contracts/reference/signed-key-request-validator.html#signedkeyrequestmetadata-struct) reference for more
+See the [Signed Key Request Validator](/reference/contracts/reference/signed-key-request-validator#signedkeyrequestmetadata-struct) reference for more
 details.

--- a/docs/developers/guides/advanced/query-signups.md
+++ b/docs/developers/guides/advanced/query-signups.md
@@ -7,7 +7,7 @@
 :::
 
 To count the number of signups by day, we can use the `chain_events` table to query the number
-of [`ID_REGISTER`](/reference/hubble/datatypes/events.html#onchaineventtype) events
+of [`ID_REGISTER`](/reference/hubble/datatypes/events#onchaineventtype) events
 and group by day.
 
 ```sql

--- a/docs/developers/guides/advanced/register-a-user.md
+++ b/docs/developers/guides/advanced/register-a-user.md
@@ -11,12 +11,12 @@
 You can register a new user using the Bundler contract. To do so, you'll need to:
 
 1. Set up [Viem](https://viem.sh/) clients and [`@farcaster/hub-web`](https://www.npmjs.com/package/@farcaster/hub-web) signers.
-2. Register an [app fid](/reference/contracts/faq.html#what-is-an-app-fid-how-do-i-get-one) if your app does not already have one.
-3. Collect a [`Register`](/reference/contracts/reference/id-gateway.html#register-signature) signature from the user.
+2. Register an [app fid](/reference/contracts/faq#what-is-an-app-fid-how-do-i-get-one) if your app does not already have one.
+3. Collect a [`Register`](/reference/contracts/reference/id-gateway#register-signature) signature from the user.
 4. Create a new signer keypair for the user.
-5. Use your app account to create a [Signed Key Request](/reference/contracts/reference/signed-key-request-validator.html).
-6. Collect an [`Add`](/reference/contracts/reference/key-gateway.html#add-signature) signature from the user.
-7. Call the [Bundler](https://docs.farcaster.xyz/reference/contracts/reference/bundler.html#register) contract to register onchain.
+5. Use your app account to create a [Signed Key Request](/reference/contracts/reference/signed-key-request-validator).
+6. Collect an [`Add`](/reference/contracts/reference/key-gateway#add-signature) signature from the user.
+7. Call the [Bundler](https://docs.farcaster.xyz/reference/contracts/reference/bundler#register) contract to register onchain.
 
 ### 1. Set up clients and signers
 

--- a/docs/developers/guides/advanced/transfer-fid.md
+++ b/docs/developers/guides/advanced/transfer-fid.md
@@ -10,7 +10,7 @@
 
 ::: warning
 Transferring an fid does not reset its recovery address. To transfer an fid and update its recovery address,
-call [`transferAndChangeRecovery`](/reference/contracts/reference/id-registry.html#transferandchangerecovery).
+call [`transferAndChangeRecovery`](/reference/contracts/reference/id-registry#transferandchangerecovery).
 :::
 
 To change the custody address of an FID to another address, you can call the `transfer` function on the ID registry

--- a/docs/developers/guides/advanced/transfer-fname.md
+++ b/docs/developers/guides/advanced/transfer-fname.md
@@ -8,7 +8,7 @@
 
 ::: warning Fname policies
 To prevent abuse, fnames can only be changed once in 28 days. See Fname
-policies [here](/learn/architecture/ens-names.html#offchain-ens-names-fnames). ENS names do not have this restriction.
+policies [here](/learn/architecture/ens-names#offchain-ens-names-fnames). ENS names do not have this restriction.
 :::
 
 To transfer an fname, e.g. `hubble`, make a POST request to `/transfers` with the following body:

--- a/docs/developers/guides/basics/setting-up.md
+++ b/docs/developers/guides/basics/setting-up.md
@@ -6,7 +6,7 @@
 
 :::
 
-See [hubble installation](/hubble/install.html) for more information on how to set up a local hubble instance.
+See [hubble installation](/hubble/install) for more information on how to set up a local hubble instance.
 
 Once the hub is running, verify that you can query it by querying the http api:
 
@@ -58,4 +58,3 @@ Ok {
 ```
 
 For more details on the GRPC API, see the [grpc api reference](/reference/hubble/grpcapi/grpcapi).
- 

--- a/docs/hubble/install.md
+++ b/docs/hubble/install.md
@@ -12,7 +12,7 @@ Hubble can be set up in less than 30 minutes. You'll need a machine that has:
 - A public IP address with ports 2282 - 2285 exposed
 - RPC endpoints for Ethereum and Optimism Mainnet. (use [Alchemy](https://www.alchemy.com/) or [Infura](https://www.infura.io/))
 
-See [tutorials](./tutorials.html) for instructions on how to set up cloud providers to run Hubble.
+See [tutorials](./tutorials) for instructions on how to set up cloud providers to run Hubble.
 
 ## Install via Script
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
 next:
   text: 'Create Your Account'
-  link: '/intro/create-account.html'
+  link: '/intro/create-account'
 ---
 
 # Getting Started

--- a/docs/reference/contracts/faq.md
+++ b/docs/reference/contracts/faq.md
@@ -4,7 +4,7 @@
 
 ### How do I generate an EIP-712 signature?
 
-See the contract reference docs for documentation on each EIP-712 signature, including Typescript [code examples](/reference/contracts/reference/id-gateway.html#register-signature).
+See the contract reference docs for documentation on each EIP-712 signature, including Typescript [code examples](/reference/contracts/reference/id-gateway#register-signature).
 
 If you're using Typescript/JS, the [`@farcaster/hub-web`](https://www.npmjs.com/package/@farcaster/hub-web) package includes tools for generating and working with EIP-712 signatures. To ensure you're using the correct addresses and typehashes, we recommend importing the ABIs and EIP-712 types from the [contracts module](https://github.com/farcasterxyz/hub-monorepo/tree/main/packages/core/src/eth/contracts) or using the provided [`Eip712Signer`](https://github.com/farcasterxyz/hub-monorepo/blob/main/packages/core/src/signers/eip712Signer.ts) helper.
 
@@ -22,7 +22,7 @@ The contracts repo is on Github [here](https://github.com/farcasterxyz/contracts
 
 ### Where do I get contract ABIs?
 
-Find contract ABIs and deployment addresses [here](/reference/contracts/deployments.html#abis).
+Find contract ABIs and deployment addresses [here](/reference/contracts/deployments#abis).
 
 ### Where can I find audit reports?
 

--- a/docs/reference/contracts/reference/bundler.md
+++ b/docs/reference/contracts/reference/bundler.md
@@ -33,27 +33,27 @@ Register an fid, add one or more signers, and rent storage in a single step. For
 
 **RegistrationParams struct**
 
-The `RegistrationParams` struct includes registration parameters and an IdGateway [`Register`](/reference/contracts/reference/id-gateway.html#register-signature) signature from the fid recipient.
+The `RegistrationParams` struct includes registration parameters and an IdGateway [`Register`](/reference/contracts/reference/id-gateway#register-signature) signature from the fid recipient.
 
-| Parameter | type      | Description                                                                                                         |
-| --------- | --------- | ------------------------------------------------------------------------------------------------------------------- |
-| to        | `address` | Address to register the fid to                                                                                      |
-| recovery  | `address` | Recovery address for the new fid                                                                                    |
-| deadline  | `uint256` | Signature expiration timestamp signature                                                                            |
-| sig       | `bytes`   | EIP-712 [`Register`](/reference/contracts/reference/key-gateway.html#add-signature) signature from the `to` address |
+| Parameter | type      | Description                                                                                                    |
+| --------- | --------- | -------------------------------------------------------------------------------------------------------------- |
+| to        | `address` | Address to register the fid to                                                                                 |
+| recovery  | `address` | Recovery address for the new fid                                                                               |
+| deadline  | `uint256` | Signature expiration timestamp signature                                                                       |
+| sig       | `bytes`   | EIP-712 [`Register`](/reference/contracts/reference/key-gateway#add-signature) signature from the `to` address |
 
 **SignerParams struct**
 
-The `SignerParams` struct includes signer key parameters and a KeyGateway [`Add`](/reference/contracts/reference/key-gateway.html#add-signature) signature from the fid recipient. Callers may provide multiple `SignerParams` structs to add multiple signers at registration time.
+The `SignerParams` struct includes signer key parameters and a KeyGateway [`Add`](/reference/contracts/reference/key-gateway#add-signature) signature from the fid recipient. Callers may provide multiple `SignerParams` structs to add multiple signers at registration time.
 
-| Parameter    | type      | Description                                                                                                                            |
-| ------------ | --------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| keyType      | `uint32`  | Must be set to `1`. This is currently the only supported `keyType`.                                                                    |
-| key          | `bytes`   | Public key to add                                                                                                                      |
-| metadataType | `uint8`   | Must be set to `1`. This is currenlty the only supported `metadataType`.                                                               |
-| metadata     | `bytes`   | Encoded [`SignedKeyRequestMetadata`](/reference/contracts/reference/signed-key-request-validator.html#signedkeyrequestmetadata-struct) |
-| deadline     | `uint256` | Signature expiration timetamp                                                                                                          |
-| sig          | `bytes`   | EIP-712 [`Add`](/reference/contracts/reference/key-gateway.html#add-signature) signature from `registrationParams.to` address          |
+| Parameter    | type      | Description                                                                                                                       |
+| ------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| keyType      | `uint32`  | Must be set to `1`. This is currently the only supported `keyType`.                                                               |
+| key          | `bytes`   | Public key to add                                                                                                                 |
+| metadataType | `uint8`   | Must be set to `1`. This is currenlty the only supported `metadataType`.                                                          |
+| metadata     | `bytes`   | Encoded [`SignedKeyRequestMetadata`](/reference/contracts/reference/signed-key-request-validator#signedkeyrequestmetadata-struct) |
+| deadline     | `uint256` | Signature expiration timetamp                                                                                                     |
+| sig          | `bytes`   | EIP-712 [`Add`](/reference/contracts/reference/key-gateway#add-signature) signature from `registrationParams.to` address          |
 
 ## Errors
 

--- a/docs/reference/contracts/reference/key-gateway.md
+++ b/docs/reference/contracts/reference/key-gateway.md
@@ -24,26 +24,26 @@ Returns the next available nonce for an address. Used for generating EIP-712 sig
 
 Add a new key for the caller's fid and set its state to `Added`. Revert if the key is already registered.
 
-| Parameter    | type     | Description                                                                                                                            |
-| ------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| keyType      | `uint32` | Must be set to `1`. This is currently the only supported `keyType`.                                                                    |
-| key          | `bytes`  | The public key to add                                                                                                                  |
-| metadataType | `uint8`  | Must be set to `1`. This is currenlty the only supported `metadataType`.                                                               |
-| metadata     | `bytes`  | Encoded [`SignedKeyRequestMetadata`](/reference/contracts/reference/signed-key-request-validator.html#signedkeyrequestmetadata-struct) |
+| Parameter    | type     | Description                                                                                                                       |
+| ------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| keyType      | `uint32` | Must be set to `1`. This is currently the only supported `keyType`.                                                               |
+| key          | `bytes`  | The public key to add                                                                                                             |
+| metadataType | `uint8`  | Must be set to `1`. This is currenlty the only supported `metadataType`.                                                          |
+| metadata     | `bytes`  | Encoded [`SignedKeyRequestMetadata`](/reference/contracts/reference/signed-key-request-validator#signedkeyrequestmetadata-struct) |
 
 ### addFor
 
 Add a key on behalf of another fid by providing a signature. The owner must sign an EIP-712 `Add` message approving the key. Reverts if the key is already registered.
 
-| Parameter    | type      | Description                                                                                                                            |
-| ------------ | --------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| fidOwner     | `address` | Address of the fid owner                                                                                                               |
-| keyType      | `uint32`  | Must be set to `1`. This is currently the only supported `keyType`.                                                                    |
-| key          | `bytes`   | The public key to add                                                                                                                  |
-| metadataType | `uint8`   | Must be set to `1`. This is currenlty the only supported `metadataType`.                                                               |
-| metadata     | `bytes`   | Encoded [`SignedKeyRequestMetadata`](/reference/contracts/reference/signed-key-request-validator.html#signedkeyrequestmetadata-struct) |
-| deadline     | `uint256` | Signature expiration timestamp                                                                                                         |
-| sig          | `bytes`   | EIP-712 [`Add`](/reference/contracts/reference/key-gateway.html#add-signature) signature from `fidOwner`                               |
+| Parameter    | type      | Description                                                                                                                       |
+| ------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| fidOwner     | `address` | Address of the fid owner                                                                                                          |
+| keyType      | `uint32`  | Must be set to `1`. This is currently the only supported `keyType`.                                                               |
+| key          | `bytes`   | The public key to add                                                                                                             |
+| metadataType | `uint8`   | Must be set to `1`. This is currenlty the only supported `metadataType`.                                                          |
+| metadata     | `bytes`   | Encoded [`SignedKeyRequestMetadata`](/reference/contracts/reference/signed-key-request-validator#signedkeyrequestmetadata-struct) |
+| deadline     | `uint256` | Signature expiration timestamp                                                                                                    |
+| sig          | `bytes`   | EIP-712 [`Add`](/reference/contracts/reference/key-gateway#add-signature) signature from `fidOwner`                               |
 
 #### Add signature
 
@@ -51,15 +51,15 @@ To add a key on behalf of another account, you must provide an EIP-712 typed sig
 
 `Add(address owner,uint32 keyType,bytes key,uint8 metadataType,bytes metadata,uint256 nonce,uint256 deadline)`
 
-| Parameter    | type      | Description                                                                                                                            |
-| ------------ | --------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| owner        | `address` | Address that owns the fid. The typed message must be signed by this address.                                                           |
-| keyType      | `uint32`  | Must be set to `1`. This is currently the only supported `keyType`.                                                                    |
-| key          | `bytes`   | The public key to add                                                                                                                  |
-| metadataType | `uint8`   | Must be set to `1`. This is currenlty the only supported `metadataType`.                                                               |
-| metadata     | `bytes`   | Encoded [`SignedKeyRequestMetadata`](/reference/contracts/reference/signed-key-request-validator.html#signedkeyrequestmetadata-struct) |
-| nonce        | `uint256` | Current nonce of the `owner` address                                                                                                   |
-| deadline     | `uint256` | Signature expiration timestamp                                                                                                         |
+| Parameter    | type      | Description                                                                                                                       |
+| ------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| owner        | `address` | Address that owns the fid. The typed message must be signed by this address.                                                      |
+| keyType      | `uint32`  | Must be set to `1`. This is currently the only supported `keyType`.                                                               |
+| key          | `bytes`   | The public key to add                                                                                                             |
+| metadataType | `uint8`   | Must be set to `1`. This is currenlty the only supported `metadataType`.                                                          |
+| metadata     | `bytes`   | Encoded [`SignedKeyRequestMetadata`](/reference/contracts/reference/signed-key-request-validator#signedkeyrequestmetadata-struct) |
+| nonce        | `uint256` | Current nonce of the `owner` address                                                                                              |
+| deadline     | `uint256` | Signature expiration timestamp                                                                                                    |
 
 ::: code-group
 

--- a/docs/reference/contracts/reference/signed-key-request-validator.md
+++ b/docs/reference/contracts/reference/signed-key-request-validator.md
@@ -19,7 +19,7 @@ Typically, the primary fid is the end user and the requesting fid is an app the 
 
 ### encodeMetadata
 
-Convert a [`SignedKeyRequestMetadata`](#signedkeyrequestmetadata-struct) struct into `bytes` to pass into contract functions like [add](/reference/contracts/reference/key-gateway.html#add), [register](/reference/contracts/reference/bundler.html#register).
+Convert a [`SignedKeyRequestMetadata`](#signedkeyrequestmetadata-struct) struct into `bytes` to pass into contract functions like [add](/reference/contracts/reference/key-gateway#add), [register](/reference/contracts/reference/bundler#register).
 
 | Parameter | type                       | Description                                     |
 | --------- | -------------------------- | ----------------------------------------------- |

--- a/docs/reference/fname/api.md
+++ b/docs/reference/fname/api.md
@@ -10,7 +10,7 @@ to another fid. Unregistering an fname is a transfer from the user's fid to fid 
 ::: warning Registering an fname
 
 Note, when registering a new fname, calling this api is not sufficient. This only reserves the name to your fid. You
-must also submit a [UserDataAdd](/reference/hubble/datatypes/messages.html#_2-userdata) message to the hub
+must also submit a [UserDataAdd](/reference/hubble/datatypes/messages#_2-userdata) message to the hub
 to set this name as your username.
 
 :::

--- a/docs/reference/hubble/grpcapi/grpcapi.md
+++ b/docs/reference/hubble/grpcapi/grpcapi.md
@@ -18,5 +18,5 @@ bindings for other clients built using other languages. Note that by default, hu
 javascript [ts-proto](https://www.npmjs.com/package/ts-proto) library's serialization byte order to verify messages
 hashes. If you are using a different client, you may need to use the `data_bytes` field with the raw serialized bytes
 when calling `SubmitMessage` in order for the message to be considered valid. Refer to
-the [SubmitMessage HTTP API docs](/reference/hubble/httpapi/submitmessage.html#using-with-rust-go-or-other-programing-languages)
+the [SubmitMessage HTTP API docs](/reference/hubble/httpapi/submitmessage#using-with-rust-go-or-other-programing-languages)
 for more details.


### PR DESCRIPTION
Remove `.html` suffix from URLs.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Update various links in the documentation to remove file extensions and improve consistency.

### Detailed summary:
- Updated the link for "Create Your Account" in `docs/index.md`.
- Added the `cleanUrls` option in `docs/.vitepress/config.ts`.
- Updated the link for "tutorials" in `docs/hubble/install.md`.
- Updated the link for "hubble installation" in `docs/developers/guides/basics/setting-up.md`.
- Updated the link for "SubmitMessage HTTP API docs" in `docs/reference/hubble/grpcapi/grpcapi.md`.
- Updated the link for "ID_REGISTER" in `docs/developers/guides/advanced/query-signups.md`.
- Updated the link for "add" and "register" in `docs/reference/contracts/reference/signed-key-request-validator.md`.
- Updated the link for "Fname policies" in `docs/developers/guides/advanced/transfer-fname.md`.
- Updated the link for "here" in `docs/developers/guides/advanced/transfer-fname.md`.
- Updated the link for "Signed Key Request Validator" in `docs/developers/guides/advanced/decode-key-metadata.md`.
- Updated the link for "add" in `docs/developers/guides/advanced/add-signer.md`.
- Updated the link for "EIP-712 signature" in `docs/reference/contracts/faq.md`.
- Updated the link for "contract ABIs" in `docs/reference/contracts/faq.md`.
- Updated the link for "register" in `docs/developers/guides/advanced/register-a-user.md`.
- Updated the link for "Register" in `docs/reference/contracts/reference/bundler.md`.

> The following files were skipped due to too many changes: `docs/reference/contracts/reference/bundler.md`, `docs/reference/contracts/reference/key-gateway.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->