### PR TITLE
Add docs around Warpcast's channels API

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -274,6 +274,7 @@ export default defineConfig({
         // },
 
         { text: 'Replicator', items: [{ text: 'Schema', link: '/reference/replicator/schema' }] },
+        { text: 'Warpcast', items: [{ text: 'API Reference', link: '/reference/warpcast/api' }] },
       ],
     },
     socialLinks: [

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,3 +25,4 @@ You can post messages, follow users and organize into communities called channel
 - [Hubble APIs](./reference/hubble/architecture.md)
 - [Contract APIs](./reference/contracts/)
 - [Fname Registry APIs](./reference/fname/api.md)
+- [Warpcast APIs](/reference/warpcast/api)

--- a/docs/reference/fname/api.md
+++ b/docs/reference/fname/api.md
@@ -1,4 +1,4 @@
-# API Reference
+# FName Registry Server API Reference
 
 The [Fname registry](https://github.com/farcasterxyz/fname-registry) server is hosted at https://fnames.farcaster.xyz
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -6,3 +6,6 @@ This section provides a detailed API and technical reference for various compone
 - [Contracts](/reference/contracts/index) - Smart contract architecture, deployment addresses, ABIs
 - [FName Registry Server](/reference/fname/api) - Farcaster's offchain ENS registry API
 - [Replicator](/reference/replicator/schema) - Database schema for the replicator
+
+Additionally, here are APIs with data that that's not in the protocol (yet) that could be useful for app developers:
+- [Warpcast](/reference/warpcast/api) - Warpcast APIs

--- a/docs/reference/warpcast/api.md
+++ b/docs/reference/warpcast/api.md
@@ -1,0 +1,33 @@
+# Warpcast API Reference
+
+### Get All Channels
+Warpcast has the concept of channels which build upon FIP-2 (setting parentUrl to casts).
+You can read more about channels in the [documentation](https://www.notion.so/warpcast/Channels-4f249d22575348a5a0488b5d86f0dd1c?pvs=4).
+
+This endpoint provides metadata around all the channels in Warpcast. The endpoint requires no authentication,
+does not use any parameters and does not pagination.
+
+```bash
+curl https://api.warpcast.com/v2/all-channels | jq
+```
+
+The return object is a JSON array where each channel has the following shape:
+
+```json
+{
+  "id": "lifehacks",
+  "url": "https://warpcast.com/~/channel/lifehacks",
+  "name": "lifehacks",
+  "description": "Tips & tricks for a smoother life journey 🌟",
+  "imageUrl": "https://i.imgur.com/Fe0Q1ZJ.png",
+  "leadFid": 17672
+}
+```
+
+Properties:
+* `id` - The unique channel id that cannot be changed (called 'Name' when creating a channel)
+* `url` - The FIP-2 `parentUrl` used for main casts in the channel
+* `name` - The friendly name displayed to users (called 'Display name' when editing a channel)
+* `description` - The description of the channel
+* `imageUrl` - URL to the channel avatar
+* `loadFid` - The fid of the user who created the channel (called 'Host' in Warpcast)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds the Warpcast APIs to the documentation. 

### Detailed summary
- Added Warpcast APIs to `index.md` and `fname/api.md`
- Added Warpcast API Reference to `warpcast/api.md`
- Described the `Get All Channels` endpoint in `warpcast/api.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->