### PR TITLE
docs: rename signers to account keys

### DIFF
--- a/docs/developers/guides/accounts/register-a-user.md
+++ b/docs/developers/guides/accounts/register-a-user.md
@@ -10,17 +10,17 @@
 
 You can register a new user using the Bundler contract. To do so, you'll need to:
 
-1. Set up [Viem](https://viem.sh/) clients and [`@farcaster/hub-web`](https://www.npmjs.com/package/@farcaster/hub-web) signers.
+1. Set up [Viem](https://viem.sh/) clients and [`@farcaster/hub-web`](https://www.npmjs.com/package/@farcaster/hub-web) account keys.
 2. Register an [app fid](/reference/contracts/faq#what-is-an-app-fid-how-do-i-get-one) if your app does not already have one.
 3. Collect a [`Register`](/reference/contracts/reference/id-gateway#register-signature) signature from the user.
-4. Create a new signer keypair for the user.
+4. Create a new account key pair for the user.
 5. Use your app account to create a [Signed Key Request](/reference/contracts/reference/signed-key-request-validator).
 6. Collect an [`Add`](/reference/contracts/reference/key-gateway#add-signature) signature from the user.
 7. Call the [Bundler](https://docs.farcaster.xyz/reference/contracts/reference/bundler#register) contract to register onchain.
 
-### 1. Set up clients and signers
+### 1. Set up clients and account keys
 
-First, set up Viem clients and `@farcaster/hub-web` signers. In this example, we'll use Viem local accounts and signers, but
+First, set up Viem clients and `@farcaster/hub-web` account keys. In this example, we'll use Viem local accounts and account keys, but
 you can also use `ViemWalletEip712Signer` to connect to a user's wallet rather than a local account.
 
 ```ts
@@ -54,10 +54,10 @@ const walletClient = createWalletClient({
 });
 
 const app = privateKeyToAccount(APP_PK);
-const appSigner = new ViemLocalEip712Signer(app);
+const accountKey = new ViemLocalEip712Signer(app);
 
 const alice = privateKeyToAccount(ALICE_PK);
-const aliceSigner = new ViemLocalEip712Signer(alice);
+const aliceAccountKey = new ViemLocalEip712Signer(alice);
 
 const getDeadline = () => {
   const now = Math.floor(Date.now() / 1000);
@@ -110,7 +110,7 @@ let nonce = await publicClient.readContract({
   args: [alice.address],
 });
 
-const registerSignature = await aliceSigner.signRegister({
+const registerSignature = await aliceAccountKey.signRegister({
   to: alice.address,
   recovery: WARPCAST_RECOVERY_PROXY,
   nonce,
@@ -118,16 +118,16 @@ const registerSignature = await aliceSigner.signRegister({
 });
 ```
 
-### 4. Create a new signer keypair
+### 4. Create a new account keypair
 
-Create a new Ed25519 signer keypair for the user. In a real app, ensure you keep the user's private key secret.
+Create a new Ed25519 account keypair for the user. In a real app, ensure you keep the user's private key secret.
 
 ```ts
 const privateKeyBytes = ed.utils.randomPrivateKey();
-const signer = new NobleEd25519Signer(privateKeyBytes);
+const accountKey = new NobleEd25519Signer(privateKeyBytes);
 
-let signerPubKey = new Uint8Array();
-const signerKeyResult = await signer.getSignerKey();
+let accountPubKey = new Uint8Array();
+const accountKeyResult = await accountKey.getSignerKey();
 ```
 
 ### 5. Use your app account to create a Signed Key Request
@@ -136,12 +136,12 @@ Create a Signed Key Request, signed by your app account. To do so, you can use t
 which generates and signs the Signed Key Request.
 
 ```ts
-if (signerKeyResult.isOk()) {
-  signerPubKey = signerKeyResult.value;
+if (accountKeyResult.isOk()) {
+  accountPubKey = accountKeyResult.value;
 
-  const signedKeyRequestMetadata = await appSigner.getSignedKeyRequestMetadata({
+  const signedKeyRequestMetadata = await accountKey.getSignedKeyRequestMetadata({
     requestFid: APP_FID,
-    key: signerPubKey,
+    key: accountPubKey,
     deadline,
   });
 }
@@ -149,7 +149,7 @@ if (signerKeyResult.isOk()) {
 
 ### 6. Collect an `Add` signature from the user.
 
-Collect an EIP-712 `Add` signature from the user to authorize adding a signer key to their fid.
+Collect an EIP-712 `Add` signature from the user to authorize adding an account key to their fid.
 
 ```ts
 if (signedKeyRequestMetadata.isOk()) {
@@ -162,10 +162,10 @@ if (signedKeyRequestMetadata.isOk()) {
     args: [alice.address],
   });
 
-  const addSignature = await aliceSigner.signAdd({
+  const addSignature = await aliceAccountKey.signAdd({
     owner: alice.address,
     keyType: 1,
-    key: signerPubKey,
+    key: accountPubKey,
     metadataType: 1,
     metadata,
     nonce,
@@ -202,7 +202,7 @@ if (aliceSignature.isOk()) {
       [
         {
           keyType: 1,
-          key: bytesToHex(signerPubkey),
+          key: bytesToHex(accountPubKey),
           metadataType: 1,
           metadata: metadata,
           sig: bytesToHex(addSignature),
@@ -254,10 +254,10 @@ const walletClient = createWalletClient({
 });
 
 const app = privateKeyToAccount(APP_PK);
-const appSigner = new ViemLocalEip712Signer(app);
+const accountKey = new ViemLocalEip712Signer(app);
 
 const alice = privateKeyToAccount(ALICE_PK);
-const aliceSigner = new ViemLocalEip712Signer(alice);
+const aliceAccountKey = new ViemLocalEip712Signer(alice);
 
 const getDeadline = () => {
   const now = Math.floor(Date.now() / 1000);
@@ -314,7 +314,7 @@ let nonce = await publicClient.readContract({
   args: [alice.address],
 });
 
-const registerSignature = await aliceSigner.signRegister({
+const registerSignature = await aliceAccountKey.signRegister({
   to: alice.address,
   recovery: WARPCAST_RECOVERY_PROXY,
   nonce,
@@ -326,22 +326,22 @@ const registerSignature = await aliceSigner.signRegister({
  *******************************************************************************/
 
 /**
- *  1. Create an Ed25519 signer keypair for Alice and get the public key.
+ *  1. Create an Ed25519 account keypair for Alice and get the public key.
  */
 const privateKeyBytes = ed.utils.randomPrivateKey();
-const signer = new NobleEd25519Signer(privateKeyBytes);
+const accountKey = new NobleEd25519Signer(privateKeyBytes);
 
-let signerPubKey = new Uint8Array();
-const signerKeyResult = await signer.getSignerKey();
-if (signerKeyResult.isOk()) {
-  signerPubKey = signerKeyResult.value;
+let accountPubKey = new Uint8Array();
+const accountKeyResult = await accountKey.getSignerKey();
+if (accountKeyResult.isOk()) {
+  accountPubKey = accountKeyResult.value;
 
   /**
    *  2. Generate a Signed Key Request from the app account.
    */
-  const signedKeyRequestMetadata = await appSigner.getSignedKeyRequestMetadata({
+  const signedKeyRequestMetadata = await accountKey.getSignedKeyRequestMetadata({
     requestFid: APP_FID,
-    key: signerPubKey,
+    key: accountPubKey,
     deadline,
   });
 
@@ -360,10 +360,10 @@ if (signerKeyResult.isOk()) {
     /**
      *  Then, collect her `Add` signature.
      */
-    const addSignature = await aliceSigner.signAdd({
+    const addSignature = await aliceAccountKey.signAdd({
       owner: alice.address,
       keyType: 1,
-      key: signerPubKey,
+      key: accountPubKey,
       metadataType: 1,
       metadata,
       nonce,
@@ -399,7 +399,7 @@ if (signerKeyResult.isOk()) {
           [
             {
               keyType: 1,
-              key: bytesToHex(signerPubkey),
+              key: bytesToHex(accountPubKey),
               metadataType: 1,
               metadata: metadata,
               sig: bytesToHex(addSignature),

--- a/docs/developers/guides/accounts/transfer-fname.md
+++ b/docs/developers/guides/accounts/transfer-fname.md
@@ -33,14 +33,14 @@ To generate the EIP-712 signature, use the following code:
 ```js
 import { makeUserNameProofClaim, EIP712Signer } from '@farcaster/hub-nodejs';
 
-const signer: EIP712Signer = undefined; // Signer for the custody address (use appropriate subclass from hub-nodejs for ethers or viem)
+const accountKey: EIP712Signer = undefined; // Account Key for the custody address (use appropriate subclass from hub-nodejs for ethers or viem)
 
 const claim = makeUserNameProofClaim({
   name: 'hubble',
   owner: '0x...',
   timestamp: Math.floor(Date.now() / 1000),
 });
-const signature = (await signer.signUserNameProofClaim(claim))._unsafeUnwrap();
+const signature = (await accountKey.signUserNameProofClaim(claim))._unsafeUnwrap();
 ```
 
 Example request via curl:

--- a/docs/developers/guides/writing/adv-casts.md
+++ b/docs/developers/guides/writing/adv-casts.md
@@ -3,7 +3,7 @@
 ::: info Pre-requisites
 
 - Write access to a hubble instance
-- Private key of a signer registered to an fid
+- Private key of an app key registered to an fid
 
 :::
 
@@ -17,9 +17,9 @@ First import the `makeCastAdd` function and set up constants
 ```ts
 import { makeCastAdd, NobleEd25519Signer, FarcasterNetwork } from '@farcaster/hub-nodejs';
 
-const SIGNER_PRIVATE_KEY: Hex = '0x...'; // Your registered signer's private key
+const APP_KEY_PRIVATE_KEY: Hex = '0x...'; // Your registered app key's private key
 const FID = -1; // Your fid
-const ed25519Signer = new NobleEd25519Signer(SIGNER_PRIVATE_KEY);
+const ed25519Signer = new NobleEd25519Signer(APP_KEY_PRIVATE_KEY);
 const dataOptions = {
   fid: FID,
   network: FC_NETWORK,

--- a/docs/developers/guides/writing/casts.md
+++ b/docs/developers/guides/writing/casts.md
@@ -3,7 +3,7 @@
 ::: info Pre-requisites
 
 - Write access to a hubble instance
-- Private key of a signer registered to an fid
+- Private key of an account key registered to an fid
 - Local typescript development environment
 
 :::

--- a/docs/developers/guides/writing/create-channel-casts.md
+++ b/docs/developers/guides/writing/create-channel-casts.md
@@ -3,7 +3,7 @@
 ::: info Pre-requisites
 
 - Write access to a hubble instance
-- Private key of a signer registered to an fid
+- Private key of an app key registered to an fid
 
 :::
 
@@ -34,9 +34,9 @@ First import the `makeCastAdd` function and set up constants
 ```ts
 import { makeCastAdd, NobleEd25519Signer, FarcasterNetwork } from '@farcaster/hub-nodejs';
 
-const SIGNER_PRIVATE_KEY: Hex = '0x...'; // Your registered signer's private key
+const APP_KEY_PRIVATE_KEY: Hex = '0x...'; // Your registered app key's private key
 const FID = -1; // Your fid
-const ed25519Signer = new NobleEd25519Signer(SIGNER_PRIVATE_KEY);
+const ed25519Signer = new NobleEd25519Signer(APP_KEY_PRIVATE_KEY);
 const dataOptions = {
   fid: FID,
   network: FC_NETWORK,

--- a/docs/developers/guides/writing/verify-address.md
+++ b/docs/developers/guides/writing/verify-address.md
@@ -3,14 +3,14 @@
 ::: info Pre-requisites
 
 - Write access to a hubble instance
-- Private key of a signer registered to an fid
+- Private key of an account key registered to an fid
 - An ethereum provider URL for OP Mainnet (e.g. via [Alchemy](https://www.alchemy.com/) or [Infura](https://www.infura.io/)).
 
 :::
 
 To create a [Verification](https://docs.farcaster.xyz/reference/hubble/datatypes/messages.html#_6-verification) proving ownership of an external Ethereum address, you can use an `Eip712Signer` to sign a verification messsage, and the `makeVerificationAddEthAddress` function to construct a message to send to a Hub.
 
-First, set up clients and signers:
+First, set up clients and account keys:
 
 ```ts
 import {

--- a/docs/examples/contracts/signer.ts
+++ b/docs/examples/contracts/signer.ts
@@ -2,11 +2,11 @@ import * as ed from '@noble/ed25519';
 import { NobleEd25519Signer } from '@farcaster/hub-web';
 
 const privateKeyBytes = ed.utils.randomPrivateKey();
-export const signer = new NobleEd25519Signer(privateKeyBytes);
+export const accountKey = new NobleEd25519Signer(privateKeyBytes);
 
 export const getPublicKey = async () => {
-  const signerKeyResult = await signer.getSignerKey();
-  if (signerKeyResult.isOk()) {
-    return signerKeyResult.value;
+  const accountKeyResult = await accountKey.getSignerKey();
+  if (accountKeyResult.isOk()) {
+    return accountKeyResult.value;
   }
 };

--- a/docs/reference/contracts/faq.md
+++ b/docs/reference/contracts/faq.md
@@ -46,7 +46,7 @@ Call the [`recoveryOf`](https://optimistic.etherscan.io/address/0x00000000fc6c5f
 
 Call the [`idOf`](https://optimistic.etherscan.io/address/0x00000000fc6c5f01fc30151999387bb99a9f489b#readContract#F14) function on the [IdRegistry](/reference/contracts/reference/id-registry.md).
 
-### How do I look up the signer keys for my fid?
+### How do I look up the account keys for my fid?
 
 Call the [`keysOf`](https://optimistic.etherscan.io/address/0x00000000fc1237824fb747abde0ff18990e59b7e#readContract#F16) function on the [KeyRegistry](/reference/contracts/reference/key-registry.md).
 

--- a/docs/reference/contracts/reference/bundler.md
+++ b/docs/reference/contracts/reference/bundler.md
@@ -22,7 +22,7 @@ Get the price in wei to register an fid, including 1 storage unit. To add additi
 
 ### register
 
-Register an fid, add one or more signers, and rent storage in a single step. For a detailed usage example, see the [signup demo app](https://farcaster-signup-demo.vercel.app/bundler).
+Register an fid, add one or more keys, and rent storage in a single step. For a detailed usage example, see the [signup demo app](https://farcaster-signup-demo.vercel.app/bundler).
 
 | Parameter      | type                 | Description                                   |
 | -------------- | -------------------- | --------------------------------------------- |
@@ -44,7 +44,7 @@ The `RegistrationParams` struct includes registration parameters and an IdGatewa
 
 **SignerParams struct**
 
-The `SignerParams` struct includes signer key parameters and a KeyGateway [`Add`](/reference/contracts/reference/key-gateway#add-signature) signature from the fid recipient. Callers may provide multiple `SignerParams` structs to add multiple signers at registration time.
+The `SignerParams` struct includes signer key parameters and a KeyGateway [`Add`](/reference/contracts/reference/key-gateway#add-signature) signature from the fid recipient. Callers may provide multiple `SignerParams` structs to add multiple keys at registration time.
 
 | Parameter    | type      | Description                                                                                                                       |
 | ------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/reference/fname/api.md
+++ b/docs/reference/fname/api.md
@@ -88,14 +88,14 @@ To generate the EIP-712 signature, use the following code:
 ```js
 import { makeUserNameProofClaim, EIP712Signer } from '@farcaster/hub-nodejs';
 
-const signer: EIP712Signer = undefined; // Signer for the custody address (use appropriate subclass from hub-nodejs for ethers or viem)
+const accountKey: EIP712Signer = undefined; // Account key for the custody address (use appropriate subclass from hub-nodejs for ethers or viem)
 
 const claim = makeUserNameProofClaim({
   name: 'hubble',
   owner: '0x...',
   timestamp: Math.floor(Date.now() / 1000),
 });
-const signature = (await signer.signUserNameProofClaim(claim))._unsafeUnwrap();
+const signature = (await accountKey.signUserNameProofClaim(claim))._unsafeUnwrap();
 ```
 
 This is the exact same kind of signature used in the ENS UsernameProofs provided to hubs to prove ownership of an ENS

--- a/docs/reference/hubble/grpcapi/onchain.md
+++ b/docs/reference/hubble/grpcapi/onchain.md
@@ -1,16 +1,16 @@
 # OnChainEvents API
 
-Used to retrieve on chain events (id registry, signers, storage rent)
+Used to retrieve on chain events (id registry, keys, storage rent)
 
 ## API
 
 | Method Name                        | Request Type                    | Response Type        | Description                                                                                                 |
 |------------------------------------|---------------------------------|----------------------|-------------------------------------------------------------------------------------------------------------|
 | GetOnChainSigner                   | SignerRequest                   | OnChainEvent         | Returns the onchain event for an active signer for an Fid                                                   |
-| GetOnChainSignersByFid             | FidRequest                      | OnChainEventResponse | Returns all active signers add events for an Fid                                                            |
+| GetOnChainSignersByFid             | FidRequest                      | OnChainEventResponse | Returns all active account keys (signers) add events for an Fid                                                            |
 | GetIdRegistryOnChainEvent          | FidRequest                      | OnChainEvent         | Returns the most recent register/transfer on chain event for an fid                                         |
 | GetIdRegistryOnChainEventByAddress | IdRegistryEventByAddressRequest | OnChainEvent         | Returns the registration/transfer event by address if it exists (allows looking up fid by address)          |
-| GetOnChainEvents                   | OnChainEventRequest             | OnChainEventResponse | Returns all on chain events filtered by type for an Fid (includes inactive signers and expired rent events) |
+| GetOnChainEvents                   | OnChainEventRequest             | OnChainEventResponse | Returns all on chain events filtered by type for an Fid (includes inactive keys and expired rent events) |
 
 ## Signer Request
 

--- a/docs/reference/hubble/httpapi/httpapi.md
+++ b/docs/reference/hubble/httpapi/httpapi.md
@@ -43,7 +43,7 @@ try {
 
 Responses from the API are encoded as `application/json`, and can be parsed as normal JSON objects.
 
-1. Hashes, ETH addresses, signers etc... are all encoded as hex strings starting with `0x`
+1. Hashes, ETH addresses, keys etc... are all encoded as hex strings starting with `0x`
 2. Signatures and other binary fields are encoded in base64
 3. Constants are encoded as their string types. For example, the `hashScheme` is encoded as `HASH_SCHEME_BLAKE3` which is equivalent to the `HASH_SCHEME_BLAKE3 = 1` from the protobuf schema.
 

--- a/docs/reference/hubble/httpapi/onchain.md
+++ b/docs/reference/hubble/httpapi/onchain.md
@@ -2,7 +2,7 @@
 
 ## onChainSignersByFid
 
-Get a list of signers provided by an FID
+Get a list of account keys (signers) provided by an FID
 
 **Query Parameters**
 | Parameter | Description | Example |
@@ -45,7 +45,7 @@ curl http://127.0.0.1:2281/v1/onChainSignersByFid?fid=6833
 
 ## onChainEventsByFid
 
-Get a list of signers provided by an FID
+Get a list of account keys provided by an FID
 
 **Query Parameters**
 | Parameter | Description | Example |

--- a/docs/reference/hubble/httpapi/submitmessage.md
+++ b/docs/reference/hubble/httpapi/submitmessage.md
@@ -88,7 +88,7 @@ try {
 
 ## Using with Rust, Go or other programing languages
 
-Messages need to be signed with a ED25519 signer belonging to the FID. If you are using a different programming language than Typescript, you can manually construct the `MessageData` object and serialize it to the `data_bytes` field of the message. Then, use the `data_bytes` to compute the `hash` and `signature`. Please see the [`rust-submitmessage` example](https://github.com/farcasterxyz/hub-monorepo/tree/main/packages/hub-web/examples) for more details
+Messages need to be signed with a Ed25519 account key belonging to the FID. If you are using a different programming language than Typescript, you can manually construct the `MessageData` object and serialize it to the `data_bytes` field of the message. Then, use the `data_bytes` to compute the `hash` and `signature`. Please see the [`rust-submitmessage` example](https://github.com/farcasterxyz/hub-monorepo/tree/main/packages/hub-web/examples) for more details
 
 ```rust
 use ed25519_dalek::{SecretKey, Signer, SigningKey};

--- a/docs/reference/protocol/concepts.md
+++ b/docs/reference/protocol/concepts.md
@@ -22,7 +22,7 @@ Farcaster operates its own offchain namespace under `fcast.id`. Every Farcaster 
 
 ## Signers
 
-A Signer is a cryptographic key pair used to sign messages. Each account can have multiple signers, which is helpful if you want to share account ownership or use many apps simultaneously. Farcaster manages signers onchain using a KeyRegistry contract.
+A Signer is a cryptographic key pair used to sign messages. Each account can have multiple account keys, which is helpful if you want to share account ownership or use many apps simultaneously. Farcaster manages account keys onchain using a KeyRegistry contract.
 
 Signers are [Ed25519 keys](https://en.wikipedia.org/wiki/EdDSA#Ed25519) that are generated offchain. An account registers a signer by making a transaction to the KeyRegistry with the signer's public key. The private key can then be used to sign and publish messages to the network.
 
@@ -30,7 +30,7 @@ Signers are [Ed25519 keys](https://en.wikipedia.org/wiki/EdDSA#Ed25519) that are
 
 Messages are public updates to Farcaster. Updates can be making a post, following someone, or adding a profile picture. The network supports many message types, and each has its own properties, requirements, and semantics. Messages are stored entirely offchain on Farcaster Hubs.
 
-A message is encoded as a [protobuf](https://protobuf.dev/) and must be hashed and signed by the account's signer. Users can publish messages to Hubs as long as they have sufficient storage. Hubs check the validity of each message's signers before accepting them.
+A message is encoded as a [protobuf](https://protobuf.dev/) and must be hashed and signed by the account's signer. Users can publish messages to Hubs as long as they have sufficient storage. Hubs check the validity of each message's account keys before accepting them.
 
 ## Storage
 

--- a/docs/reference/replicator/schema.md
+++ b/docs/reference/replicator/schema.md
@@ -40,7 +40,7 @@ Stores all registered FIDs on the Farcaster network.
 
 ## signers
 
-Stores all registered signers.
+Stores all registered account keys (signers).
 
  Column Name           | Data Type                  | Description                                                                                                  
 -----------------------|----------------------------|--------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Signers are an important concept in Farcaster, but the term is confusing for two reasons: 

1. Describes what it does rather than what it is
2. Conflicts with the name of the contract (key registry should register keys not signers) 

A more descriptive name is "account key" - it tells you that the object is a key and that it gives you access to an account, which makes its purpose very clear. I've made a draft PR that renames signer to account key in many places so that you can get a feel for how the term reads in documentation and code. Looking for feedback on whether this is a clear improvements (I think it is). 

If we do believe this is the right path forward, we will also need to: 

- Alias and eventually deprecate Hubble API's (e.g. getOnchainSigners) 
- Migrate replicator tables (signers) 
- Alias and eventually deprecate library exports

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
Update terminology from "signers" to "account keys" in various documentation files.

### Detailed summary:
- Update terminology from "signers" to "account keys" in `casts.md` under `docs/developers/guides/writing/`
- Update terminology from "signers" to "account keys" in `schema.md` under `docs/reference/replicator/`
- Update terminology from "signers" to "account keys" in `onchain.md` and `httpapi.md` under `docs/reference/hubble/httpapi/`
- Update terminology from "signers" to "account keys" in `signer.ts` under `docs/examples/contracts/`
- Update terminology from "signers" to "account keys" in `faq.md` under `docs/reference/contracts/`
- Update terminology from "signers" to "account keys" in `httpapi.md` under `docs/reference/hubble/httpapi/`
- Update terminology from "signers" to "account keys" in `transfer-fname.md` under `docs/developers/guides/accounts/`
- Update terminology from "signers" to "account keys" in `verify-address.md` under `docs/developers/guides/writing/`
- Update terminology from "signers" to "account keys" in `adv-casts.md` under `docs/developers/guides/writing/`
- Update terminology from "signers" to "account keys" in `create-channel-casts.md` under `docs/developers/guides/writing/`
- Update terminology from "signers" to "account keys" in `api.md` under `docs/reference/fname/`
- Update terminology from "signers" to "account keys" in `submitmessage.md` under `docs/reference/hubble/httpapi/`
- Update terminology from "signers" to "account keys" in `bundler.md` under `docs/reference/contracts/reference/`
- Update terminology from "signers" to "account keys" in `concepts.md` under `docs/reference/protocol/`
- Update terminology from "signers" to "account keys" in `onchain.md` under `docs/reference/hubble/grpcapi/`

> The following files were skipped due to too many changes: `docs/reference/hubble/grpcapi/onchain.md`, `docs/developers/guides/basics/hello-world.md`, `docs/developers/guides/accounts/register-a-user.md`, `docs/developers/guides/accounts/add-signer.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->