### PR TITLE
fix: add mobile link

### DIFF
--- a/docs/connect-kit/introduction.md
+++ b/docs/connect-kit/introduction.md
@@ -6,6 +6,8 @@ ConnectKit is a [React](https://react.dev/) library that makes it easy to add Si
 
 Click the "Sign in With Farcaster" button below, then scan the QR code with your phone to sign in with Farcaster.
 
+(On mobile? [Click here to try the demo](https://sign-in-with-farcaster-demo.replit.app/)).
+
 <iframe src="https://sign-in-with-farcaster-demo.replit.app/" width="700" height="600" />
 
 ## Features


### PR DESCRIPTION
Add separate link for mobile demo.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the "Introduction" section of the Connect Kit documentation. 

### Detailed summary:
- Added a link to a mobile demo for "Sign in With Farcaster"
- Added an iframe to embed the mobile demo on the page

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->