### PR TITLE
chore: remove tip callout blocks

### DIFF
--- a/docs/connect-kit/client/introduction.md
+++ b/docs/connect-kit/client/introduction.md
@@ -12,9 +12,7 @@ Install the Connect client and its peer dependencies [viem](https://viem.sh/) an
 npm install @farcaster/connect viem ethers
 ```
 
-::: tip
-Connect is a low level client library. If you're using React, take a look at [ConnectKit](../introduction) instead.
-:::
+**Note:** Connect is a low level client library. If you're using React, take a look at [ConnectKit](../introduction) instead.
 
 ### Create a client
 
@@ -29,9 +27,7 @@ const appClient = createAppClient({
 });
 ```
 
-::: tip
 Depending on the type of app you're building, you may use an `AppClient` or an `AuthClient`. If you're building a connected app and logging in users, use an _app client_. If you're building a Farcaster wallet app, use an _auth client_.
-:::
 
 ### Consume actions
 

--- a/docs/connect-kit/connect-button.md
+++ b/docs/connect-kit/connect-button.md
@@ -2,6 +2,8 @@
 
 The main component. Renders a "Sign in With Farcaster" button that prompts the user to scan a QR code with their phone in a web browser or redirects on a mobile device. You can use the `onSuccess` callback prop or the `useUserData` hook to access the user's authentication status and profile information.
 
+**Note:** Make sure you've wrapped your application in a [`ConnectKitProvider`](./connect-kit-provider.md) to use the `ConnectButton` component.
+
 ```tsx
 import { ConnectButton } from '@farcaster/connect-kit';
 

--- a/docs/connect-kit/connect-kit-provider.md
+++ b/docs/connect-kit/connect-kit-provider.md
@@ -2,6 +2,8 @@
 
 Wrap your application in a `ConnectKitProvider` to use Farcaster Connect. This provider component stores configuration information about your app and makes it available to ConnectKit components and hooks.
 
+**Note:** You must create a `ConnectKitProvider` to use Farcaster Connect.
+
 ```tsx
 const config = {
   domain: 'example.com',

--- a/docs/connect-kit/installation.md
+++ b/docs/connect-kit/installation.md
@@ -6,9 +6,7 @@ Install ConnectKit and its peer dependencies [viem](https://viem.sh/) and [ether
 npm install @farcaster/connect-kit viem ethers
 ```
 
-::: tip
-ConnectKit is a [React](https://react.dev/) library. If you're using a different framework, take a look at the [client library](./client/introduction.md) instead.
-:::
+**Note:** ConnectKit is a [React](https://react.dev/) library. If you're using a different framework, take a look at the [client library](./client/introduction.md) instead.
 
 ### Import
 


### PR DESCRIPTION
🚧 

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Added a note in `connect-kit-provider.md` to inform users that they need to create a `ConnectKitProvider` to use Farcaster Connect.
- Updated the note in `connect-kit/connect-button.md` to remind users to wrap their application in a `ConnectKitProvider` before using the `ConnectButton` component.
- Updated the note in `client/introduction.md` to suggest using `ConnectKit` instead of `Connect` for React applications.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->