### PR TITLE
feat: add embedded demo apps

### DIFF
--- a/docs/auth-kit/examples.md
+++ b/docs/auth-kit/examples.md
@@ -4,10 +4,14 @@
 
 A frontend-only app which lets users Sign in with Farcaster and shows them their profile picture and username.
 
-Try Demo | [View Source](https://github.com/farcasterxyz/connect-monorepo/tree/main/examples/frontend-only)
+<iframe src="https://farcaster-auth-kit-vite-demo.replit.app/" width="700" height="500" />
+
+[Try Demo](https://farcaster-auth-kit-vite-demo.replit.app/) | [View Source](https://github.com/farcasterxyz/connect-monorepo/tree/main/examples/frontend-only)
 
 ## Server Side
 
 A Next.js app which lets users Sign in with Farcaster and handles sessions server-side.
 
-Try Demo | [View Source](https://github.com/farcasterxyz/connect-monorepo/tree/main/examples/with-next-auth)
+<iframe src="https://farcaster-auth-kit-next-auth-demo.replit.app/" width="700" height="500" />
+
+[Try Demo](https://farcaster-auth-kit-next-auth-demo.replit.app/) | [View Source](https://github.com/farcasterxyz/connect-monorepo/tree/main/examples/with-next-auth)


### PR DESCRIPTION
Link to embedded demo apps on Replit.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the demo links and adds iframes for better visualization. 

### Detailed summary
- Updated demo links for the frontend-only app and the server-side app.
- Added iframes to display the demos directly on the page.
- Updated the "View Source" links for both apps.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->