### PR TITLE
docs: add warpcast cast composer intents reference

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -547,7 +547,10 @@ export default defineConfig({
         },
         {
           text: 'Warpcast',
-          items: [{ text: 'API Reference', link: '/reference/warpcast/api' }],
+          items: [
+            { text: 'API Reference', link: '/reference/warpcast/api' },
+            { text: 'Cast Composer Intents', link: '/reference/warpcast/cast-composer-intents' },
+          ],
         },
       ],
     },

--- a/docs/reference/warpcast/cast-composer-intents.md
+++ b/docs/reference/warpcast/cast-composer-intents.md
@@ -1,0 +1,28 @@
+# Warpcast Cast Composer Intens
+
+Warpcast intents enable builders to direct authenticated users to a pre-filled cast composer.
+
+#### Compose with cast text
+
+```bash
+https://warpcast.com/~/compose?text=Hello%20world!
+```
+
+#### Compose with cast text and one embed
+
+```bash
+https://warpcast.com/~/compose?text=Hello%20world!&embeds[]=https://farcaster.xyz
+```
+
+#### Compose with cast text with mentions and two embeds
+
+```bash
+https://warpcast.com/~/compose?text=Hello%20@farcaster!&embeds[]=https://farcaster.xyz&embeds[]=https://github.com/farcasterxyz/protocol
+```
+
+#### Additional details
+
+- Embeds are any valid URLs
+- URLs ending with `.png` `.jpg` or `.gif` will render as an image embed
+- Embedding the URL to a Zora mint page will render the NFT with a mint link below it.
+- You can check how embeds will be rendered in Warpcast at https://warpcast.com/~/developers/embeds


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new section to the Warpcast documentation called "Cast Composer Intents". It includes examples and details on how to compose casts with different parameters, such as text, embeds, and mentions. 

### Detailed summary
- Added a new file `docs/reference/warpcast/cast-composer-intents.md`
- Added a new section called "Warpcast Cast Composer Intents"
- Included examples and details on composing casts with different parameters
- Added information on embeds, including valid URLs and rendering options
- Provided a link to preview how embeds will be rendered in Warpcast

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->