### PR TITLE
docs: warpcast embeds reference

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -550,6 +550,7 @@ export default defineConfig({
           items: [
             { text: 'API Reference', link: '/reference/warpcast/api' },
             { text: 'Cast Composer Intents', link: '/reference/warpcast/cast-composer-intents' },
+            { text: 'Embeds', link: '/reference/warpcast/embeds' },
           ],
         },
       ],

--- a/docs/reference/warpcast/embeds.md
+++ b/docs/reference/warpcast/embeds.md
@@ -1,0 +1,11 @@
+# Warpcast Embeds Reference
+
+Warpcast follows the [Open Graph protocol](https://ogp.me) when rendering rich previews for URL embeds.
+
+Developers can reset existing embed caches on Warpcast at https://warpcast.com/~/developers/embeds.
+
+#### Additional details
+
+- Resetting an embed cache, does not reset Open Graph image caches. If you are experiencing a stale image on your Open Graph, change the image file path served as the `og:image`.
+- Developers have to be logged in to Warpcast to access this page.
+- Warpcast extends Open Graph protocol for special NFT rendering, spec can be found at [NFT Extended Open Graph (Warpcast Notion)](https://warpcast.notion.site/NFT-extended-Open-Graph-Spec-4e350bd8e4c34e3b86e77d58bf1f5575)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new section to the documentation called "Warpcast Embeds Reference". It provides information on how Warpcast handles URL embeds and includes additional details on resetting embed caches and accessing special NFT rendering. 

### Detailed summary
- Added `docs/reference/warpcast/embeds.md` file
- Added content for Warpcast Embeds Reference
- Included information on the Open Graph protocol and resetting embed caches
- Mentioned that developers need to be logged in to access the page
- Provided a link to the NFT Extended Open Graph spec

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->