### PR TITLE
Add link to view OpenAPI spec in redocly

### DIFF
--- a/docs/reference/hubble/httpapi/httpapi.md
+++ b/docs/reference/hubble/httpapi/httpapi.md
@@ -39,6 +39,10 @@ try {
 }
 ```
 
+**OpenAPI Spec**
+
+An OpenAPI spec is provided for the Hubble REST API. It can be viewed [here](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/farcasterxyz/hub-monorepo/main/packages/hub-nodejs/spec.yaml).
+
 ## Response encoding
 
 Responses from the API are encoded as `application/json`, and can be parsed as normal JSON objects.


### PR DESCRIPTION
Links to the spec introduced to the hub-monorepo here: https://github.com/farcasterxyz/hub-monorepo/pull/1537

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a link to the OpenAPI spec for the Hubble REST API in the documentation.

### Detailed summary
- Added a link to the OpenAPI spec for the Hubble REST API in the documentation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->