### PR TITLE
feat: update docs for auth-kit@0.1.x

### DIFF
--- a/docs/auth-kit/auth-kit-provider.md
+++ b/docs/auth-kit/auth-kit-provider.md
@@ -25,14 +25,14 @@ const App = () => {
 
 | Prop     | Type            | Required | Description                                           |
 | -------- | --------------- | -------- | ----------------------------------------------------- |
-| `config` | `AuthKitConfig` | Yes      | Configuration object. See options in the table below. |
+| `config` | `AuthKitConfig` | No       | Configuration object. See options in the table below. |
 
 `config` object options:
 
 | Parameter | Type     | Required | Description                        | Default                       |
 | --------- | -------- | -------- | ---------------------------------- | ----------------------------- |
-| `domain`  | `string` | Yes      | The domain of your application.    | None                          |
-| `siweUri` | `string` | Yes      | The login URL of your application. | None                          |
+| `domain`  | `string` | No       | The domain of your application.    | `window.location.host`        |
+| `siweUri` | `string` | No       | The login URL of your application. | `window.location.href`        |
 | `relay`   | `string` | No       | Farcaster Auth relay server URL    | `https://relay.farcaster.xyz` |
 | `rpcUrl`  | `string` | No       | Optimism RPC server URL            | `https://mainnet.optimism.io` |
 | `version` | `string` | No       | Farcaster Auth version             | `v1`                          |

--- a/docs/auth-kit/client/app/status.md
+++ b/docs/auth-kit/client/app/status.md
@@ -33,23 +33,27 @@ const status = await appClient.status({
         bio?: string
         displayName?: string
         pfpUrl?: string
+        custody?: Hex;
+        verifications?: Hex[];
     }
     isError: boolean
     error: Error
 }
 ```
 
-| Parameter          | Description                                                                                                                        |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `response`         | HTTP response from the Connect relay server.                                                                                       |
-| `data.state`       | Status of the sign in request, either `"pending"` or `"complete"`                                                                  |
-| `data.nonce`       | Random nonce used in the SIWE message. If you don't provide a custom nonce as an argument to the hook, you should read this value. |
-| `data.message`     | The generated SIWE message.                                                                                                        |
-| `data.signature`   | Hex signature produced by the user's Warpcast wallet.                                                                              |
-| `data.fid`         | User's Farcaster ID.                                                                                                               |
-| `data.username`    | User's Farcaster username.                                                                                                         |
-| `data.bio`         | User's Farcaster bio.                                                                                                              |
-| `data.displayName` | User's Farcaster display name.                                                                                                     |
-| `data.pfpUrl`      | User's Farcaster profile picture URL.                                                                                              |
-| `isError`          | True when an error has occurred.                                                                                                   |
-| `error`            | `Error` instance.                                                                                                                  |
+| Parameter            | Description                                                                                                                        |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `response`           | HTTP response from the Connect relay server.                                                                                       |
+| `data.state`         | Status of the sign in request, either `"pending"` or `"complete"`                                                                  |
+| `data.nonce`         | Random nonce used in the SIWE message. If you don't provide a custom nonce as an argument to the hook, you should read this value. |
+| `data.message`       | The generated SIWE message.                                                                                                        |
+| `data.signature`     | Hex signature produced by the user's Warpcast wallet.                                                                              |
+| `data.fid`           | User's Farcaster ID.                                                                                                               |
+| `data.username`      | User's Farcaster username.                                                                                                         |
+| `data.bio`           | User's Farcaster bio.                                                                                                              |
+| `data.displayName`   | User's Farcaster display name.                                                                                                     |
+| `data.pfpUrl`        | User's Farcaster profile picture URL.                                                                                              |
+| `data.custody`       | User's FID custody address.                                                                                                        |
+| `data.verifications` | List of user's verified addresses.                                                                                                 |
+| `isError`            | True when an error has occurred.                                                                                                   |
+| `error`              | `Error` instance.                                                                                                                  |

--- a/docs/auth-kit/client/app/watch-status.md
+++ b/docs/auth-kit/client/app/watch-status.md
@@ -40,23 +40,27 @@ const status = await appClient.watchStatus({
         bio?: string
         displayName?: string
         pfpUrl?: string
+        custody?: Hex;
+        verifications?: Hex[];
     }
     isError: boolean
     error: Error
 }
 ```
 
-| Parameter          | Description                                                                                                                        |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `response`         | HTTP response from the Connect relay server.                                                                                       |
-| `data.state`       | Status of the sign in request, either `"pending"` or `"complete"`                                                                  |
-| `data.nonce`       | Random nonce used in the SIWE message. If you don't provide a custom nonce as an argument to the hook, you should read this value. |
-| `data.message`     | The generated SIWE message.                                                                                                        |
-| `data.signature`   | Hex signature produced by the user's Warpcast wallet.                                                                              |
-| `data.fid`         | User's Farcaster ID.                                                                                                               |
-| `data.username`    | User's Farcaster username.                                                                                                         |
-| `data.bio`         | User's Farcaster bio.                                                                                                              |
-| `data.displayName` | User's Farcaster display name.                                                                                                     |
-| `data.pfpUrl`      | User's Farcaster profile picture URL.                                                                                              |
-| `isError`          | True when an error has occurred.                                                                                                   |
-| `error`            | `Error` instance.                                                                                                                  |
+| Parameter            | Description                                                                                                                        |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `response`           | HTTP response from the Connect relay server.                                                                                       |
+| `data.state`         | Status of the sign in request, either `"pending"` or `"complete"`                                                                  |
+| `data.nonce`         | Random nonce used in the SIWE message. If you don't provide a custom nonce as an argument to the hook, you should read this value. |
+| `data.message`       | The generated SIWE message.                                                                                                        |
+| `data.signature`     | Hex signature produced by the user's Warpcast wallet.                                                                              |
+| `data.fid`           | User's Farcaster ID.                                                                                                               |
+| `data.username`      | User's Farcaster username.                                                                                                         |
+| `data.bio`           | User's Farcaster bio.                                                                                                              |
+| `data.displayName`   | User's Farcaster display name.                                                                                                     |
+| `data.pfpUrl`        | User's Farcaster profile picture URL.                                                                                              |
+| `data.custody`       | User's FID custody address.                                                                                                        |
+| `data.verifications` | List of user's verified addresses.                                                                                                 |
+| `isError`            | True when an error has occurred.                                                                                                   |
+| `error`              | `Error` instance.                                                                                                                  |

--- a/docs/auth-kit/hooks/use-profile.md
+++ b/docs/auth-kit/hooks/use-profile.md
@@ -10,7 +10,7 @@ import { useProfile } from '@farcaster/auth-kit';
 function App {
   const {
     isAuthenticated,
-    userData: { username, fid, bio, displayName, pfpUrl },
+    profile: { username, fid, bio, displayName, pfpUrl },
   } = useProfile();
 
   return (
@@ -32,21 +32,25 @@ function App {
 ```ts
   {
     isAuthenticated: boolean;
-    userData?: {
+    profile?: {
         fid?: number;
         username?: string;
         bio?: string;
         displayName?: string;
         pfpUrl?: string;
+        custody?: Hex;
+        verifications?: Hex[];
     },
   };
 ```
 
-| Parameter              | Description                      |
-| ---------------------- | -------------------------------- |
-| `isAuthenticated`      | True when the user is logged in. |
-| `userData.fid`         | User's Farcaster ID.             |
-| `userData.username`    | User's username.                 |
-| `userData.bio`         | User's bio text.                 |
-| `userData.displayName` | User's display name.             |
-| `userData.pfpUrl`      | User's profile picture URL.      |
+| Parameter               | Description                        |
+| ----------------------- | ---------------------------------- |
+| `isAuthenticated`       | True when the user is logged in.   |
+| `profile.fid`           | User's Farcaster ID.               |
+| `profile.username`      | User's username.                   |
+| `profile.bio`           | User's bio text.                   |
+| `profile.displayName`   | User's display name.               |
+| `profile.pfpUrl`        | User's profile picture URL.        |
+| `profile.custody`       | User's FID custody address.        |
+| `profile.verifications` | List of user's verified addresses. |

--- a/docs/auth-kit/hooks/use-sign-in.md
+++ b/docs/auth-kit/hooks/use-sign-in.md
@@ -5,15 +5,15 @@ Hook for signing in a user. Connects to the relay server, generates a QR code an
 If you want to build your own sign in component with custom UI, use the `useSignIn` hook.
 
 ```tsx
-import { useSignIn } from "@farcaster/auth-kit";
+import { useSignIn } from '@farcaster/auth-kit';
 
 function App() {
   const {
     signIn,
     qrCodeUri,
-    data: { username }
+    data: { username },
   } = useSignIn({
-    onSuccess: ({ fid }) => console.log("Your fid:", fid)
+    onSuccess: ({ fid }) => console.log('Your fid:', fid),
   });
 
   return (
@@ -49,7 +49,10 @@ function App() {
 ```ts
   {
     signIn: () => void;
+    signOut: () => void;
+    connect: () => void;
     reconnect: () => void;
+    isConnected: boolean;
     isSuccess: boolean;
     isPolling: boolean;
     isError: boolean;
@@ -57,6 +60,7 @@ function App() {
     channelToken: string;
     url: string;
     qrCodeUri: string;
+    appClient: AppClient;
     data: {
         state: "pending" | "complete";
         nonce: string;
@@ -67,29 +71,37 @@ function App() {
         bio: string;
         displayName: string;
         pfpUrl: string;
+        custody?: Hex;
+        verifications?: Hex[];
     },
     validSignature: boolean;
   };
 ```
 
-| Parameter          | Description                                                                                                                        |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `signIn`           | Call this function to connect to the relay and begin polling for a signature.                                                      |
-| `reconnect`        | Reconnect to the relay and try again. Call this in the event of an error.                                                          |
-| `isSuccess`        | True when the relay server returns a valid signature.                                                                              |
-| `isPolling`        | True when the relay state is `"pending"` and the app is polling the relay server for a response.                                   |
-| `isError`          | True when an error has occurred.                                                                                                   |
-| `error`            | `AuthClientError` instance.                                                                                                        |
-| `channelToken`     | Connect relay channel token.                                                                                                       |
-| `url`              | Sign in With Farcaster URL to present to the user. Links to Warpcast in v1.                                                        |
-| `qrcodeUri`        | QR code image data URL encoding `url`.                                                                                             |
-| `data.state`       | Status of the sign in request, either `"pending"` or `"complete"`                                                                  |
-| `data.nonce`       | Random nonce used in the SIWE message. If you don't provide a custom nonce as an argument to the hook, you should read this value. |
-| `data.message`     | The generated SIWE message.                                                                                                        |
-| `data.signature`   | Hex signature produced by the user's Warpcast wallet.                                                                              |
-| `data.fid`         | User's Farcaster ID.                                                                                                               |
-| `data.username`    | User's Farcaster username.                                                                                                         |
-| `data.bio`         | User's Farcaster bio.                                                                                                              |
-| `data.displayName` | User's Farcaster display name.                                                                                                     |
-| `data.pfpUrl`      | User's Farcaster profile picture URL.                                                                                              |
-| `validSignature`   | True when the signature returned by the relay server is valid.                                                                     |
+| Parameter            | Description                                                                                                                        |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `signIn`             | Call this function following `connect` to begin polling for a signature.                                                           |
+| `signOut`            | Call this function to clear the AuthKit state and sign out the user.                                                               |
+| `connect`            | Connect to the auth relay and create a channel.                                                                                    |
+| `reconnect`          | Reconnect to the relay and try again. Call this in the event of an error.                                                          |
+| `isConnected`        | True if AuthKit is connected to the relay server and has an active channel.                                                        |
+| `isSuccess`          | True when the relay server returns a valid signature.                                                                              |
+| `isPolling`          | True when the relay state is `"pending"` and the app is polling the relay server for a response.                                   |
+| `isError`            | True when an error has occurred.                                                                                                   |
+| `error`              | `AuthClientError` instance.                                                                                                        |
+| `channelToken`       | Connect relay channel token.                                                                                                       |
+| `url`                | Sign in With Farcaster URL to present to the user. Links to Warpcast in v1.                                                        |
+| `qrcodeUri`          | QR code image data URL encoding `url`.                                                                                             |
+| `appClient`          | Underlying `AppClient` instance.                                                                                                   |
+| `data.state`         | Status of the sign in request, either `"pending"` or `"complete"`                                                                  |
+| `data.nonce`         | Random nonce used in the SIWE message. If you don't provide a custom nonce as an argument to the hook, you should read this value. |
+| `data.message`       | The generated SIWE message.                                                                                                        |
+| `data.signature`     | Hex signature produced by the user's Warpcast wallet.                                                                              |
+| `data.fid`           | User's Farcaster ID.                                                                                                               |
+| `data.username`      | User's Farcaster username.                                                                                                         |
+| `data.bio`           | User's Farcaster bio.                                                                                                              |
+| `data.displayName`   | User's Farcaster display name.                                                                                                     |
+| `data.pfpUrl`        | User's Farcaster profile picture URL.                                                                                              |
+| `data.custody`       | User's FID custody address.                                                                                                        |
+| `data.verifications` | List of user's verified addresses.                                                                                                 |
+| `validSignature`     | True when the signature returned by the relay server is valid.                                                                     |

--- a/docs/auth-kit/sign-in-button.md
+++ b/docs/auth-kit/sign-in-button.md
@@ -31,6 +31,8 @@ export const Login = () => {
 | `onSuccess`        | `function` | Callback invoked when sign in is complete and the user is authenticated.            | None                  |
 | `onStatusResponse` | `function` | Callback invoked when the component receives a status update from the relay server. | None                  |
 | `onError`          | `function` | Error callback function.                                                            | None                  |
+| `onSignOut`        | `function` | Callback invoked when the user signs out.                                           | None                  |
+| `hideSignOut`      | `function` | Hide the Sign out button.                                                           | `false`               |
 | `debug`            | `boolean`  | Render a debug panel displaying internal auth-kit state.                            | `false`               |
 
 ## Examples


### PR DESCRIPTION
Update AuthKit docs for v0.1.x

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `onSignOut` callback to the `sign-in-button.md` file.
- Added `hideSignOut` function to the `sign-in-button.md` file.
- Updated the `config` object in the `auth-kit-provider.md` file to have optional properties.
- Updated the return value and parameter names in the `use-profile.md` file.
- Added `custody` and `verifications` properties to the `profile` object in the `use-profile.md` file.
- Updated the parameter names and added `custody` and `verifications` properties to the response data in the `status.md` and `watch-status.md` files.

> The following files were skipped due to too many changes: `docs/auth-kit/client/app/watch-status.md`, `docs/auth-kit/hooks/use-sign-in.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->