### PR TITLE
chore: update demo URL

### DIFF
--- a/docs/auth-kit/introduction.md
+++ b/docs/auth-kit/introduction.md
@@ -4,7 +4,7 @@
 
 AuthKit is a React library that lets users log in to your app with a Farcaster account.
 
-<iframe src="https://sign-in-with-farcaster-demo.replit.app/" width="700" height="500" />
+<iframe src="https://farcaster-auth-kit-vite-demo.replit.app/" width="700" height="500" />
 
 Click "Sign in With Farcaster" above to try it out on web or click [here](https://sign-in-with-farcaster-demo.replit.app/) for mobile.
 


### PR DESCRIPTION
Use updated demo URL on AuthKit docs page.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the iframe source URL in the `introduction.md` file of the `auth-kit` documentation.

### Detailed summary
- Updated the iframe source URL to `https://farcaster-auth-kit-vite-demo.replit.app/`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->