### PR TITLE
fix typo

### DIFF
--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -11,11 +11,10 @@ Getting a hub set up lets you start querying data. Roughly speaking, a hub is to
 
 ## 2. Hello World
 
-The Hello World example will walk you through the basics of creating a new acccount and writing your first message.
+The Hello World example will walk you through the basics of creating a new account and writing your first message.
 
 1. If you've never used Farcaster, [start with Warpcast](../learn/intro/create-account.md).
 2. If you've used Farcaster, complete the [Hello World](/developers/guides/basics/hello-world) example.
-3. If you've used Farcaster, complete the [Hello World](/developers/guides/basics/hello-world) example.
 
 ## 3. Explore advanced topics
 


### PR DESCRIPTION
small typos

remove dupe item
acccount -> account

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a typo in the documentation and removing a duplicate line. 

### Detailed summary
- Fixed a typo in the documentation: "acccount" changed to "account".
- Removed a duplicate line in the documentation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->