### PR TITLE
Add validateMessage docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -416,8 +416,8 @@ export default defineConfig({
                   link: '/reference/hubble/grpcapi/verification',
                 },
                 {
-                  text: 'SubmitMessage API',
-                  link: '/reference/hubble/grpcapi/submitmessage',
+                  text: 'Message API',
+                  link: '/reference/hubble/grpcapi/message',
                 },
                 { text: 'Fids API', link: '/reference/hubble/grpcapi/fids' },
                 {
@@ -463,8 +463,8 @@ export default defineConfig({
                   link: '/reference/hubble/httpapi/verification',
                 },
                 {
-                  text: 'SubmitMessage API',
-                  link: '/reference/hubble/httpapi/submitmessage',
+                  text: 'Message API',
+                  link: '/reference/hubble/httpapi/message',
                 },
                 { text: 'Fids API', link: '/reference/hubble/httpapi/fids' },
                 {

--- a/docs/reference/hubble/datatypes/messages.md
+++ b/docs/reference/hubble/datatypes/messages.md
@@ -2,7 +2,8 @@
 
 A message is the fundamental data type in the Farcaster network.
 
-When an account takes an action like casting a public message, change its profile or verifying an Ethereum account, it generates a new messages
+When an account takes an action like casting a public message, change its profile or verifying an Ethereum account, it
+generates a new messages
 
 ## 1. Message
 
@@ -20,7 +21,8 @@ The message is a protobuf that contains the data, its hash and a signature from 
 
 ### 1.1 MessageData
 
-MessageData is a generic envelope that contains a type, fid, timestamp and network which must be present in all Farcaster messages. It also contains a body whose type is determined by the MessageType.
+MessageData is a generic envelope that contains a type, fid, timestamp and network which must be present in all
+Farcaster messages. It also contains a body whose type is determined by the MessageType.
 
 | Field     | Type                                                                                                                                                                                                                                                                                                                                    | Label | Description                                    |
 | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ---------------------------------------------- |
@@ -205,3 +207,19 @@ Removes a Verification of any type
 | Field   | Type  | Label | Description                           |
 | ------- | ----- | ----- | ------------------------------------- |
 | address | bytes |       | Address of the Verification to remove |
+
+## 7. Frame Action
+
+Represents an action performed by a user on a frame. This message is not stored on the hubs and cannot be submitted,
+only validated.
+
+### 7.1 FrameActionBody
+
+A user action on a frame
+
+| Field        | Type              | Label | Description                                           |
+| ------------ | ----------------- | ----- | ----------------------------------------------------- |
+| url          | bytes             |       | The original url of the frame as embedded in the cast |
+| button_index | uint32            |       | The button that was pressed (indexed from 1)          |
+| cast_id      | [CastId](#CastId) |       | The cast id that hosted the frame                     |
+| input_text   | bytes             |       | Any text the user input as part of the action         |

--- a/docs/reference/hubble/grpcapi/grpcapi.md
+++ b/docs/reference/hubble/grpcapi/grpcapi.md
@@ -18,5 +18,5 @@ bindings for other clients built using other languages. Note that by default, hu
 javascript [ts-proto](https://www.npmjs.com/package/ts-proto) library's serialization byte order to verify messages
 hashes. If you are using a different client, you may need to use the `data_bytes` field with the raw serialized bytes
 when calling `SubmitMessage` in order for the message to be considered valid. Refer to
-the [SubmitMessage HTTP API docs](/reference/hubble/httpapi/submitmessage#using-with-rust-go-or-other-programing-languages)
+the [SubmitMessage HTTP API docs](/reference/hubble/httpapi/message#using-with-rust-go-or-other-programing-languages)
 for more details.

--- a/docs/reference/hubble/grpcapi/message.md
+++ b/docs/reference/hubble/grpcapi/message.md
@@ -1,0 +1,18 @@
+# Message API
+
+Used to validate and send a message to the Farcaster Hub. Valid messages are accepted and gossiped to other hubs in the
+network.
+
+## API
+
+| Method Name     | Request Type | Response Type      | Description                                                  |
+| --------------- | ------------ | ------------------ | ------------------------------------------------------------ |
+| SubmitMessage   | Message      | Message            | Submits a Message to the Hub                                 |
+| ValidateMessage | Message      | ValidationResponse | Validates a Message on the Hub without merging and gossiping |
+
+## ValidationResponse Response
+
+| Field   | Type    | Label | Description                                   |
+| ------- | ------- | ----- | --------------------------------------------- |
+| valid   | boolean |       | Whether the message is valid or not           |
+| message | Message |       | The message being validated (same as request) |

--- a/docs/reference/hubble/grpcapi/message.md
+++ b/docs/reference/hubble/grpcapi/message.md
@@ -10,7 +10,7 @@ network.
 | SubmitMessage   | Message      | Message            | Submits a Message to the Hub                                 |
 | ValidateMessage | Message      | ValidationResponse | Validates a Message on the Hub without merging and gossiping |
 
-## ValidationResponse Response
+## ValidationResponse
 
 | Field   | Type    | Label | Description                                   |
 | ------- | ------- | ----- | --------------------------------------------- |

--- a/docs/reference/hubble/grpcapi/submitmessage.md
+++ b/docs/reference/hubble/grpcapi/submitmessage.md
@@ -1,9 +1,0 @@
-# SubmitMessage API
-
-Used to send a message to the Farcaster Hub. Valid messages are accepted and gossiped to other hubs in the network.
-
-## API
-
-| Method Name   | Request Type | Response Type | Description                  |
-| ------------- | ------------ | ------------- | ---------------------------- |
-| SubmitMessage | Message      | Message       | Submits a Message to the Hub |

--- a/docs/reference/hubble/httpapi/message.md
+++ b/docs/reference/hubble/httpapi/message.md
@@ -138,6 +138,7 @@ curl -X POST "http://127.0.0.1:2281/v1/validateMessage" \
       "frameActionBody": {
         "url": "https://fcpolls.com/polls/1",
         "buttonIndex": 2,
+        "inputText": "",
         "castId": {
           "fid": 226,
           "hash": "0xa48dd46161d8e57725f5e26e34ec19c13ff7f3b9"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary:

This PR updates the documentation by renaming the `SubmitMessage` API to `Message` API and making corresponding changes throughout the documentation. It also adds a new section for validating messages and provides examples for using the API with different programming languages.

Notable changes:
- Renamed `SubmitMessage` API to `Message` API
- Updated links and references to the API throughout the documentation
- Added new section for validating messages
- Provided examples for using the API with different programming languages

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->