### PR TITLE
feat: add algolia docsearch

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -68,8 +68,14 @@ export default defineConfig({
       { text: 'Website', link: 'http://www.farcaster.xyz' },
     ],
     search: {
-      provider: 'local',
-    },
+      provider: 'algolia',
+      options: {
+        appId: 'ADFEMXTYRR',
+        apiKey: '53a9b47bf4d93ee8fa655fec4274538b',
+        indexName: 'farcaster',
+        insights: true, 
+      }
+    },    
     sidebar: {
       '/': [
         {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- The search provider in the Vitepress config file has been changed from 'local' to 'algolia'.
- The Algolia search options have been added, including the appId, apiKey, indexName, and insights.
- The sidebar configuration has been updated.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->