### PR TITLE
chore: frames page edits

### DIFF
--- a/docs/reference/frames/spec.md
+++ b/docs/reference/frames/spec.md
@@ -1,21 +1,26 @@
 # Frames
 
-A frame is a set of `<meta>` tags returned within the header of an HTML page. If a page contains all required frame properties, Farcaster apps will render the page as a frame. The frame `<meta>` tags extend the [OpenGraph protocol](https://ogp.me/).
+Frames are a standard for creating interactive and authenticated experiences on Farcaster, embeddable in any Farcaster client.
 
-Frames can be linked together to create dynamic applications that can be rendered inside Farcaster applications.
+A frame is a set of `<meta>` tags returned within the `<head>` of an HTML page. If a page contains all required frame properties, Farcaster apps will render the page as a frame. The frame `<meta>` tags extend the [OpenGraph protocol](https://ogp.me/).
+
+Frames can be linked together to create dynamic applications embedded inside casts.
 
 ## Lifecycle of a frame app
 
-A frame app begins with an initial frame which is cached by apps and shown to users. The frame may have buttons, which when clicked load other frames or redirect the user to external websites.
+A frame app begins with an initial frame which is cached by apps and shown to users. A frame must have an image. It may have buttons, which when clicked load other frames or redirect the user to external websites.
 
 ![Frame App](/assets/frame_app.png)
 
 ### Initial Frames
 
-A frame app lives at a URL (e.g. foo.com/app) on the frame server. The frame server:
+A frame is an HTML web application that lives at a URL (e.g. foo.com/app) on a web server. We'll refer to this web server as the "frame server."
 
-- Must return a valid frame in the HTTP headers
-- Should return a body, in case the user clicks through to the frame in a browser.
+The frame server:
+
+- Must return a valid frame in the HTML `<head>` section.
+- Should return a valid HTML `<body>`, in case the user clicks through to the frame in a browser.
+- Should not include dynamic content in the initial frame, since it is cached by Farcaster clients.
 
 ### Response Frames
 
@@ -26,23 +31,24 @@ When a frame server receives a POST request:
 - It must respond within 5 seconds.
 - It must respond with a 200 OK and another frame, on a `post` button click.
 - It must respond with a 302 OK and a Location header, on a `post_redirect` button click.
-- Any location header provided must contain a URL that starts with `http` or `https`.
+- Any Location header provided must contain a URL that starts with `http://` or `https://`.
 
 ### Best Practices
 
 Follow these best practices to work around the limitations of frames:
 
 - Start your initial frame with a load button if you must show dynamic content.
-- Add timestamps or uuids to image urls on subsequent frames to bust caches.
+- Add timestamps or UUIDs to image urls on subsequent frames to bust caches.
 - Return a frame with a "refresh" button if your response takes > 5 seconds.
 
 ### Rendering Frames
 
 A frame enters Farcaster when a user creates a cast and embeds the frame URL in it. An app that wants to support frames must:
 
-- Check all call cast embed URLS for valid frames.
-- If the frame is valid, it must render the frame when the cast is viewed.
-- If the frame is malformed, it falls back to treating it as an OpenGraph embed.
+- Check all call cast embed URLs for valid frames.
+- If the frame is valid, render the frame when the cast is viewed.
+- If the frame is malformed, fall back to treating it as an OpenGraph embed.
+- Follow the frame [security model](#securing-frames).
 
 ## Constructing a frame
 
@@ -58,18 +64,18 @@ A frame property is a meta tag with a property and a content value. The properti
 
 ### Required Properties
 
-| Key              | Type   | Description                                                                                                                                                                               |
-| ---------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `fc:frame`       | string | A valid frame version string. The string must be a release date (e.g. 2020-01-01) or vNext. Apps must ignore versions they do not understand. Currently, the only valid version is vNext. |
-| `fc:frame:image` | string | An image which should have an aspect ratio of 1.91:1                                                                                                                                      |
-| `og:image`       | string | An image which should have an aspect ratio of 1.91:1. Fallback for clients that do not support frames.                                                                                    |
+| Key              | Type   | Description                                                                                                                                                                                     |
+| ---------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fc:frame`       | string | A valid frame version string. The string must be a release date (e.g. `"2020-01-01"`) or `"vNext. Apps must ignore versions they do not understand. Currently, the only valid version is vNext. |
+| `fc:frame:image` | URL    | An image which should have an aspect ratio of 1.91:1                                                                                                                                            |
+| `og:image`       | URL    | An image which should have an aspect ratio of 1.91:1. Fallback for clients that do not support frames.                                                                                          |
 
 ### Optional Properties
 
 | Key                           | Type   | Description                                                                                                                                                                                                                                                                          |
 | ----------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `fc:frame:button:$idx`        | string | A 256-byte string which is the label of the button at position $idx. A page may contain 0 to 4 buttons. If more than 1 button is present, the idx values must be in sequence starting from 1 (e.g., 1, 2, 3). If a broken sequence is present (e.g., 1, 2, 4), the frame is invalid. |
-| `fc:frame:post_url`           | string | A 256-byte string which contains a valid URL to send the Signature Packet to.                                                                                                                                                                                                        |
+| `fc:frame:post_url`           | URL    | A 256-byte string which contains a valid URL to send the Signature Packet. to.                                                                                                                                                                                                       |
 | `fc:frame:button:$idx:action` | string | Must be `post` or `post_redirect`. Defaults to `post` if no value was specified.                                                                                                                                                                                                     |
 | `fc:frame:input:text`         | string | Adding this property enables the text field. The content is a 32-byte label that is shown to the user (e.g., Enter a message).                                                                                                                                                       |
 
@@ -79,9 +85,9 @@ There are a few rules for serving images in `fc:frame:image` tags:
 
 - The size of the image must be < 10 MB.
 - The type of image must be jpg, png or gif.
-- The image must either be a URL with content headers or a data URI.
+- The image source must either be an external resource with content headers or a data URI.
 
-Clients may resize larger images or crop those that do not fit in their aspect ratio. SVG images are discouraged because they can contain scripts and extra work must be done by clients to sanitize them.
+Clients may resize larger images or crop those that do not fit in their aspect ratio. SVG images are forbidden because they can contain scripts and clients must do extra work to sanitize them.
 
 ## Rendering frames
 
@@ -112,8 +118,8 @@ Applications will receive responses from frame servers after a POST request is s
 
 1. If the button was a `post` button, treat all non-200 responses as errors.
 2. If the button was a `post_redirect` button, treat all non-30X responses as errors.
-3. If handling a 30X response, apps must redirect the user to the url location value.
-4. If handling a 30X response, apps must ensure the url starts with `http` or `https`.
+3. If handling a 30X response, apps must redirect the user to the Location header url.
+4. If handling a 30X response, apps must ensure the url starts with `http://` or `https://`.
 5. If handling a 30X response, warn the user before directing them to an untrusted site.
 
 ## Securing frames
@@ -123,14 +129,15 @@ Frames are highly sandboxed environments that do not allow direct access to Ethe
 ### Frame Developers
 
 1. Sanitize all input received from the user via text inputs.
+2. Verify the signature of a frame signature packet.
+3. Validate the origin URL in the frame signature packet.
 
 ### App Developers
 
 1. Proxy image requests to prevent frame servers from tracking users.
-2. Sanitize redirect URLs to ensure they start with `http` or `https`.
+2. Sanitize redirect URLs to ensure they start with `http://` or `https://`.
 3. Only accept data URIs if they are images.
-4. Avoid rendering SVG's as they may contain executable code.
-5. Validate signatures before using the data in a frame signature packet.
+4. Avoid rendering SVGs as they may contain executable code.
 
 ## Data Structures
 
@@ -140,7 +147,7 @@ A Frame signature proves that a user clicked a frame button. It is created by th
 
 When a frame button is clicked, the Farcaster app must generate a `FrameAction` protobuf. A FrameAction is a new type of [Farcaster message](https://github.com/farcasterxyz/protocol/blob/main/docs/SPECIFICATION.md#2-message-specifications). Like all FC messages, it must be signed with an active Ed25519 account key (aka signer) that belongs to the user.
 
-```protobuf
+```proto
 message FrameActionBody {
   bytes frame_url = 1;    // The URL of the frame app
   bytes button_index = 2; // The index of the button that was clicked
@@ -176,7 +183,7 @@ A FrameActionBody in a message `m` is valid only if it passes these validation
 
 A signature packet is a JSON object sent to the Frame server when a button is clicked. It contains two objects:
 
-1. **Signed Message** — an authenticated protobuf that represents the user action. must be unpacked by a farcaster hub to read the data inside.
+1. **Signed Message** — an authenticated protobuf that represents the user action. This message must be unpacked by a farcaster hub to read the data inside.
 
 2. **Unsigned Message** — an unathenticated JSON object that represents the user action. can be read directly.
 
@@ -214,6 +221,12 @@ The Signed Message can be validated by calling the `validateMessage` API on Hubs
 - the message hash is correct (contents match the hash)
 - the signature for the message is valid, and came from the signer
 - the FrameActionBody passes the above validations
+
+::: warning
+Hubs perform important validations in addition to verifying a signature packet's Ed25519 signature.
+
+Although it may be possible to validate an Ed25519 signature onchain, a valid signature is insufficient to fully authenticate a frame message packet. Applications must also check that the fid is valid, the signer key is active, and the message body is valid. Outside of OP mainnet, it is difficult to perform these validations onchain.
+:::
 
 ## Improvement Proposals
 


### PR DESCRIPTION
Copyedits and clarifications to frames docs.

- Add short intro sentence.
- Clarify that `<meta>` tags are in HTML `<head>`
- Use `URL` in place of `string` type in a few places.
- Add Frame developer responsibilities
- Fix protobuf syntax highlighting
- Add onchain verification warning

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the documentation for frames in Farcaster. 

### Detailed summary
- Clarifies the definition of frames and their purpose
- Adds information on the lifecycle of a frame app
- Provides best practices for working with frames
- Explains the rendering process of frames in Farcaster
- Updates the requirements and properties of frames
- Adds information on securing frames and handling frame actions
- Includes changes to the data structures related to frames

> The following files were skipped due to too many changes: `docs/reference/frames/spec.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->