### PR TITLE
added free Pinata hub to the docs

### DIFF
--- a/docs/hubble/hubble.md
+++ b/docs/hubble/hubble.md
@@ -14,6 +14,7 @@ network.
 Hubble instances can also be hosted for you by other service providers.
 
 - [Hubs x Neynar](https://hubs.neynar.com/)
+- [Hubs X Pinata](https://pinata.cloud/pinata-hub)
 
 ## Public Instances
 


### PR DESCRIPTION
Pinata now has a free, robust Hub that developers can benefit. Added the link to Pinata's Hub to the docs.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the link to the Hubs platform from "Hubs x Neynar" to "Hubs X Pinata".

### Detailed summary
- Updated the link to the Hubs platform from "Hubs x Neynar" to "Hubs X Pinata" in the `docs/hubble/hubble.md` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->