### PR TITLE
Fix typo of merkle trees

### DIFF
--- a/docs/learn/architecture/hubs.md
+++ b/docs/learn/architecture/hubs.md
@@ -36,7 +36,7 @@ Conflicts are resolved deterministically and asynchronously using CRDTs. For exa
 
 ### Replication
 
-Hubs sync using a two-phase process - gossip and diff sync. When a Hub receives and stores a message, it immediately gossips it to its peers. Gossip is performed using libp2p's gossipsub protocol and is lossy. Hubs then periodically select a random peer and perform a diff sync to find dropped messages. The diff sync process compares merkle tries of message hashes to efficiently find dropped messages.
+Hubs sync using a two-phase process - gossip and diff sync. When a Hub receives and stores a message, it immediately gossips it to its peers. Gossip is performed using libp2p's gossipsub protocol and is lossy. Hubs then periodically select a random peer and perform a diff sync to find dropped messages. The diff sync process compares merkle trees of message hashes to efficiently find dropped messages.
 
 ### Consistency
 


### PR DESCRIPTION
Was reading the docs site to learn about Farcaster and came across this. Seems like it is a typo.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the documentation for the replication process in hubs. The notable changes include:

- Updating the description of the diff sync process to mention the use of merkle trees instead of merkle tries.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->