### PR TITLE
docs: fix typo in contracts.md

### DIFF
--- a/docs/learn/architecture/contracts.md
+++ b/docs/learn/architecture/contracts.md
@@ -32,4 +32,4 @@ The Storage Registry lets accounts rent [storage](../what-is-farcaster/messages.
 
 ### Key Registry
 
-They Key Registry lets accounts issue keys to apps, so that they can publish messages on their behalf. Keys can be added or removed at any time. To add a key, an account must submit the public key of an EdDSA key pair along with a requestor signature. The requestor can be the account itself or an app that wants to operate on its behalf.
+The Key Registry lets accounts issue keys to apps, so that they can publish messages on their behalf. Keys can be added or removed at any time. To add a key, an account must submit the public key of an EdDSA key pair along with a requestor signature. The requestor can be the account itself or an app that wants to operate on its behalf.


### PR DESCRIPTION
"They Key Registry..." updated to "The Key Registry"

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Updated a typo in the `Key Registry` section of the `contracts.md` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->