### PR TITLE
docs: remove non-functional connected apps

### DIFF
--- a/docs/learn/what-is-farcaster/apps.md
+++ b/docs/learn/what-is-farcaster/apps.md
@@ -29,8 +29,6 @@ Some popular connected apps include:
 
 - [Supercast](https://supercast.xyz/)
 - [Yup](https://yup.io/)
-- [Tiles](https://tiles.cool/)
-- [Opencast](https://opencast.stephancill.co.za/)
 - [Farcord](https://farcord.com/)
 
 **Connected apps are not reviewed by Farcaster, use them at your own risk**


### PR DESCRIPTION
Removed tiles and opencast as they aren't functional anymore, gives a bad look to newcomers otherwise

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes two app links from the `apps.md` file: Tiles and Opencast.

### Detailed summary
- Removed [Tiles](https://tiles.cool/) app link.
- Removed [Opencast](https://opencast.stephancill.co.za/) app link.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->