### PR TITLE
docs: fix grammar issue in hubs.md

### DIFF
--- a/docs/learn/architecture/hubs.md
+++ b/docs/learn/architecture/hubs.md
@@ -26,7 +26,7 @@ Alice's message is validated by checking that it has a valid signature from one 
 
 ### Storage
 
-Alice's message is then check for conflicts before being stored in the Hub. Conflicts can occur for many reasons:
+Alice's message is then checked for conflicts before being stored in the Hub. Conflicts can occur for many reasons:
 
 1. The hub already has a copy of the message.
 2. The hub has a later message from Alice deleting this message.


### PR DESCRIPTION
Fixed the grammar typo "...is then check" to "... is then checked"

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary:

- Fixed a typo in the `hubs.md` file by correcting the word "check" to "checked" in the sentence about storing Alice's message in the Hub.
- Added two reasons for conflicts that can occur when storing messages in the Hub: 
  1. The Hub already has a copy of the message.
  2. The Hub has a later message from Alice deleting this message.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->