### PR TITLE
fix: add imports referenced in example code to hello world example

### DIFF
--- a/docs/developers/guides/basics/hello-world.md
+++ b/docs/developers/guides/basics/hello-world.md
@@ -30,7 +30,9 @@ import {
   keyGatewayABI,
   ID_REGISTRY_ADDRESS,
   idRegistryABI,
+  FarcasterNetwork,
 } from '@farcaster/hub-web';
+import { zeroAddress } from 'viem';
 import { optimism } from 'viem/chains';
 
 /**

--- a/docs/developers/guides/basics/hello-world.md
+++ b/docs/developers/guides/basics/hello-world.md
@@ -31,6 +31,7 @@ import {
   ID_REGISTRY_ADDRESS,
   idRegistryABI,
 } from '@farcaster/hub-web';
+import { optimism } from 'viem/chains';
 
 /**
  * Populate the following constants with your own values


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary:

- Added `FarcasterNetwork` import from `@farcaster/hub-web`
- Added `zeroAddress` import from `viem`
- Added `optimism` import from `viem/chains`

These changes add new imports to the file `docs/developers/guides/basics/hello-world.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->