### PR TITLE
docs: add frames resources, farcaster epoch, minor navigation cleanups

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -146,7 +146,7 @@ export default defineConfig({
             { text: 'Overview', link: '/developers/index' },
             {
               text: 'Basics',
-              collapsed: false,
+              collapsed: true,
               items: [
                 {
                   text: 'Hello World',
@@ -154,9 +154,20 @@ export default defineConfig({
                 },
               ],
             },
+
+            {
+              text: 'Creating frames',
+              collapsed: true,
+              items: [
+                {
+                  text: 'Create a poll frame',
+                  link: '/developers/guides/frames/poll',
+                },
+              ],
+            },
             {
               text: 'Managing accounts',
-              collapsed: false,
+              collapsed: true,
               items: [
                 {
                   text: 'Create an account',
@@ -186,7 +197,7 @@ export default defineConfig({
             },
             {
               text: 'Querying data',
-              collapsed: false,
+              collapsed: true,
               items: [
                 {
                   text: 'Get account messages',
@@ -204,7 +215,7 @@ export default defineConfig({
             },
             {
               text: 'Writing data',
-              collapsed: false,
+              collapsed: true,
               items: [
                 {
                   text: 'Create messages',
@@ -226,7 +237,7 @@ export default defineConfig({
             },
             {
               text: 'Building apps',
-              collapsed: false,
+              collapsed: true,
               items: [
                 {
                   text: 'Replicate to Postgres',
@@ -237,16 +248,6 @@ export default defineConfig({
                 // { text: 'Build a farcaster client', link: '/developers/guides/applications/client' },
                 // { text: 'Read data with Farcaster Auth', link: '/developers/guides/applications/todo' },
                 // { text: 'Write data with Farcaster Auth', link: '/developers/guides/applications/todo' },
-              ],
-            },
-            {
-              text: 'Creating frames',
-              collapsed: false,
-              items: [
-                {
-                  text: 'Create a poll frame',
-                  link: '/developers/guides/frames/poll',
-                },
               ],
             },
             {

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -15,7 +15,6 @@ The Hello World example will walk you through the basics of creating a new accco
 
 1. If you've never used Farcaster, [start with Warpcast](../learn/intro/create-account.md).
 2. If you've used Farcaster, complete the [Hello World](/developers/guides/basics/hello-world) example.
-3. If you've used Farcaster, complete the [Hello World](/developers/guides/basics/hello-world) example.
 
 ## 3. Explore advanced topics
 

--- a/docs/learn/what-is-farcaster/frames.md
+++ b/docs/learn/what-is-farcaster/frames.md
@@ -10,7 +10,35 @@ Frames extend the OpenGraph standard and turn static embeds into interactive exp
 
 Creating a frame is simple — choose an image to show and add buttons the user can click on. If a button is clicked, you get a callback and can send another image with more buttons.
 
-### Learn More
+## Resources
 
-- Build a frame with a [tutorial](../../developers/guides/frames/poll.md).
-- Read the [Frame specification](../../reference/frames/spec.md).
+A collection of the most popular utilities for creating and managing frames.
+
+### Learning
+
+- [Specification](<(../../reference/frames/spec.md).>) - A formal specification for the Frame standard.
+- [Video: Frames 101](https://youtu.be/rp9X8rAPzPM?si=PWm3vBFCTtaoE_Ua) - A beginner's guide to frames.
+- [Tutorial: Polls](../../developers/guides/frames/poll.md) - Create a simple poll with frames.
+
+### Tools
+
+- [Vercel OG](https://vercel.com/docs/functions/og-image-generation) - Use satori and resvg-js to generate PNG images from HTML and CSS.
+- [Warpcast Frame Validator](https://warpcast.com/~/developers/frames) - A debugger for testing frames in Warpcast UI.
+- [Neynar](https://docs.neynar.com/docs/how-to-build-farcaster-frames-with-neynar) - Infrastructure and tools for frame servers.
+
+### Frameworks
+
+- [onchainkit](https://github.com/coinbase/onchainkit) - A React toolkit to create frames
+- [frames.js](https://framesjs.org/) - A Next.js template for building and debugging frames.
+- [Simplest Frame](https://github.com/depatchedmode/simplest-frame) - a zero-framework frame template.
+
+### Examples
+
+- [Linktree](https://replit.com/@soren/Linktree-Frame?v=1) - a simple frame that links to four other pages.
+- [Onchain Cow](https://github.com/WillPapper/On-Chain-Cow-Farcaster-Frame) - a cow clicker-like game.
+- [FC Polls](https://github.com/farcasterxyz/fc-polls) - create and run polls within frames.
+- [Claim or Mint](https://github.com/horsefacts/base-mint-with-warps) - lets users claim an NFT if the meet certain criteria.
+
+<br/>
+
+A more detailed list of resources can be found at [awesome-frames](https://github.com/davidfurlong/awesome-frames).

--- a/docs/learn/what-is-farcaster/frames.md
+++ b/docs/learn/what-is-farcaster/frames.md
@@ -16,7 +16,7 @@ A collection of the most popular utilities for creating and managing frames.
 
 ### Learning
 
-- [Specification](<(../../reference/frames/spec.md).>) - A formal specification for the Frame standard.
+- [Specification](../../reference/frames/spec.md) - A formal specification for the Frame standard.
 - [Video: Frames 101](https://youtu.be/rp9X8rAPzPM?si=PWm3vBFCTtaoE_Ua) - A beginner's guide to frames.
 - [Tutorial: Polls](../../developers/guides/frames/poll.md) - Create a simple poll with frames.
 

--- a/docs/reference/hubble/httpapi/httpapi.md
+++ b/docs/reference/hubble/httpapi/httpapi.md
@@ -53,7 +53,7 @@ Responses from the API are encoded as `application/json`, and can be parsed as n
 
 ## Timestamps
 
-Messages contain a timestamp, which is the _Farcaster Epoch Timestamp_ (and not the Unix Epoch).
+Messages contain timestamps which are seconds since the Farcaster Epoch, which began on Jan 1, 2021 00:00:00 UTC.
 
 ## Paging
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- Updated the documentation to clarify that messages contain timestamps in seconds since the Farcaster Epoch.
- Removed duplicate item in the developers index page.
- Collapsed the "Basics" and "Managing accounts" sections in the Vitepress config.
- Collapsed the "Creating frames", "Querying data", and "Writing data" sections in the Vitepress config.
- Added a new "Creating frames" section in the Vitepress config.
- Updated the "Learn More" section in the "Creating a frame" page with new resources.
- Added a new "Resources" section in the "Creating a frame" page with various learning, tools, frameworks, and examples resources.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->