### PR TITLE
Update spec.md to fix wrong key name

### DIFF
--- a/docs/reference/frames/spec.md
+++ b/docs/reference/frames/spec.md
@@ -131,7 +131,7 @@ If the button is a `mint` action, the following rules also apply:
 If the button clicked is a `post` or `post_redirect`, apps must:
 
 1. Construct a Frame Signature Packet.
-2. POST the packet to `fc:frame:button:$idx:action:target` if present
+2. POST the packet to `fc:frame:button:$idx:target` if present
 3. POST the packet to `fc:frame:post_url` if target was not present.
 4. POST the packet to or the frame's embed URL if neither target nor action were present.
 5. Wait at least 5 seconds for a response from the frame server.


### PR DESCRIPTION
The key mentioned doesn't exist and it's confusing

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- The focus of this PR is to update the endpoint URL in the code.
- The `fc:frame:button:$idx:action:target` endpoint has been changed to `fc:frame:button:$idx:target`.
- The `fc:frame:post_url` endpoint is now used if the target was not present.
- The code now waits at least 5 seconds for a response from the frame server.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->