### PR TITLE
Rename userData to profile to fix useProfile example

### DIFF
--- a/docs/auth-kit/installation.md
+++ b/docs/auth-kit/installation.md
@@ -56,7 +56,7 @@ import { useProfile } from '@farcaster/auth-kit';
 export const UserProfile = () => {
   const {
     isAuthenticated,
-    userData: { username, fid },
+    profile: { username, fid },
   } = useProfile();
   return (
     <div>


### PR DESCRIPTION
When using userData, it throws an error.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Renamed the `userData` object to `profile` in the `useProfile` hook.
- Destructured `username` and `fid` properties from the `profile` object instead of the `userData` object.
- Updated the code to use the new `profile` object and its properties.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->