### PR TITLE
Docs: fix useSignInMessage import in example

### DIFF
--- a/docs/auth-kit/hooks/use-sign-in-message.md
+++ b/docs/auth-kit/hooks/use-sign-in-message.md
@@ -5,7 +5,7 @@ Hook for reading the Sign in With Farcaster message and signature used to authen
 If you're providing the message and signature to a backend API, you may want to use this hook.
 
 ```tsx
-import { useUserData } from '@farcaster/auth-kit';
+import { useSignInMessage } from '@farcaster/auth-kit';
 
 function App() {
   const { message, signature } = useSignInMessage();


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on replacing the usage of `useUserData` with `useSignInMessage` in the `App` component.

### Detailed summary
- Replaced `useUserData` import with `useSignInMessage` import.
- Destructured `message` and `signature` from the `useSignInMessage` hook.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->