### PR TITLE
Update fetch-channel-casts.md

### DIFF
--- a/docs/developers/guides/querying/fetch-channel-casts.md
+++ b/docs/developers/guides/querying/fetch-channel-casts.md
@@ -8,7 +8,7 @@
 
 To fetch casts from a channel, Hubble provides a `getCastsByParent` api call.
 
-For example, to query all casts to the etehreurm channel:
+For example, to query all casts to the ethereum channel:
 
 ```bash
 $ curl http://localhost:2281/v1/castsByParent\?fid\=1\&url\="https://ethereum.org" | jq " .messages | limit(10;.[]) | .data.castAddBody.text"


### PR DESCRIPTION
fix typo:
etehreurm --> ethereum

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Renamed the channel from "etehreurm" to "ethereum" in the documentation.
- Updated an example curl command to query casts to the "ethereum" channel.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->