### PR TITLE
Update installation.md

### DIFF
--- a/docs/auth-kit/installation.md
+++ b/docs/auth-kit/installation.md
@@ -56,7 +56,7 @@ import { useProfile } from '@farcaster/auth-kit';
 export const UserProfile = () => {
   const {
     isAuthenticated,
-    userData: { username, fid },
+    profile: { username, fid },
   } = useProfile();
   return (
     <div>


### PR DESCRIPTION
updated the `useProfile` installation example to have the proper type of `profile` instead of `userData`

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Renamed `userData` to `profile` in the `useProfile` hook.
- Destructured `username` and `fid` from the `profile` object instead of `userData`.

This PR focuses on renaming and restructuring variables in the `useProfile` hook.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->