### PR TITLE
Add image caching suggestions for more dynamic updates on first frame

### DIFF
--- a/docs/reference/frames/spec.md
+++ b/docs/reference/frames/spec.md
@@ -93,6 +93,11 @@ There are a few rules for serving images in `fc:frame:image` tags:
 
 Clients may resize larger images or crop those that do not fit in their aspect ratio. SVG images are not because they can contain scripts and extra work must be done by clients to sanitize them.
 
+Frame servers can use cache headers to refresh images and offer more dynamic first frame experiences:
+
+- Frame servers can use the `max-age` directive in the HTTP `Cache-Control` header to ensure images in the initial frame refresh automatically. A lower `max-age` ensures images update regularly without user interactions.
+- App developers should respect cache headers set by the original frame image, and their image proxy implementations should not interfere with durations.
+
 ## Displaying frames in a feed
 
 Farcaster apps are responsible for rendering frames to users and proxying their interactions back to the frame server on their behalf.


### PR DESCRIPTION
<img width="723" alt="image" src="https://github.com/farcasterxyz/docs/assets/19259594/75ae9058-fb9a-49e2-9b17-2a5c5bbafbc8">

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances frame server capabilities by introducing the use of cache headers for image refreshment. It also emphasizes the importance of respecting cache headers for app developers.

### Detailed summary
- Introduces the use of cache headers for frame servers to refresh images
- Highlights the `max-age` directive in the HTTP `Cache-Control` header for automatic image refreshment
- Emphasizes the need for app developers to respect cache headers set by original frame images

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->