### PR TITLE
docs: typo for closing tag </AuthKitProvider>

### DIFF
--- a/docs/auth-kit/auth-kit-provider.md
+++ b/docs/auth-kit/auth-kit-provider.md
@@ -16,7 +16,7 @@ const App = () => {
   return (
     <AuthKitProvider config={config}>
       {/*   Your App   */}
-    </SignInProvider>
+    </AuthKitProvider>
   );
 };
 ```


### PR DESCRIPTION
Closing tag is incorrect at https://docs.farcaster.xyz/auth-kit/auth-kit-provider#authkitprovider 

![image](https://github.com/farcasterxyz/docs/assets/20764957/2c316dfc-101c-489f-80f2-d1bf80ce0782)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `AuthKitProvider` component in the `auth-kit-provider.md` file.

### Detailed summary
- Replaced `SignInProvider` with `AuthKitProvider` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->