### PR TITLE
improve readability by fixing the spacing in Ethereum provider URL list references

### DIFF
--- a/docs/developers/guides/accounts/change-custody.md
+++ b/docs/developers/guides/accounts/change-custody.md
@@ -7,7 +7,7 @@ A user may want to change this address for security reasons or to transfer owner
 ### Requirements
 
 - An ETH wallet that owns the account on OP mainnet, with some ETH
-- An ethereum provider URL for OP Mainnet (e.g. via [Alchemy](https://www.alchemy.com/),[Infura](https://www.infura.io/) or [QuickNode](https://www.quicknode.com/)).
+- An ethereum provider URL for OP Mainnet (e.g. via [Alchemy](https://www.alchemy.com/), [Infura](https://www.infura.io/) or [QuickNode](https://www.quicknode.com/)).
 
 ### Change Custody Address
 

--- a/docs/developers/guides/accounts/change-recovery.md
+++ b/docs/developers/guides/accounts/change-recovery.md
@@ -5,7 +5,7 @@ Accounts can configure a recovery address to protect against the loss of the cus
 ### Requirements
 
 - An ETH wallet that has an fid on OP mainnet, with some ETH for gas costs
-- An ETH RPC URL for OP Mainnet (e.g. via [Alchemy](https://www.alchemy.com/),[Infura](https://www.infura.io/) or [QuickNode](https://www.quicknode.com/)).
+- An ETH RPC URL for OP Mainnet (e.g. via [Alchemy](https://www.alchemy.com/), [Infura](https://www.infura.io/) or [QuickNode](https://www.quicknode.com/)).
 
 ### Change Address
 

--- a/docs/developers/guides/accounts/create-account-key.md
+++ b/docs/developers/guides/accounts/create-account-key.md
@@ -14,7 +14,7 @@ The owner of the account can revoke an account key at any time. To add an accoun
 ### Requirements
 
 - An ETH wallet on OP mainnet, with some ETH
-- An ETH RPC URL for OP Mainnet (e.g. via [Alchemy](https://www.alchemy.com/),[Infura](https://www.infura.io/) or [QuickNode](https://www.quicknode.com/)).
+- An ETH RPC URL for OP Mainnet (e.g. via [Alchemy](https://www.alchemy.com/), [Infura](https://www.infura.io/) or [QuickNode](https://www.quicknode.com/)).
 
 ### 1. Set up clients and account key
 

--- a/docs/developers/guides/accounts/create-account.md
+++ b/docs/developers/guides/accounts/create-account.md
@@ -3,7 +3,7 @@
 ::: info Pre-requisites
 
 - An Ethereum wallet on Optimism mainnet, with sufficient ETH for gas costs
-- An ethereum provider URL for OP Mainnet ((e.g. via [Alchemy](https://www.alchemy.com/),[Infura](https://www.infura.io/) or [QuickNode](https://www.quicknode.com/)).
+- An ethereum provider URL for OP Mainnet ((e.g. via [Alchemy](https://www.alchemy.com/), [Infura](https://www.infura.io/) or [QuickNode](https://www.quicknode.com/)).
 
 :::
 

--- a/docs/developers/guides/basics/hello-world.md
+++ b/docs/developers/guides/basics/hello-world.md
@@ -17,7 +17,7 @@ repository [here](https://github.com/farcasterxyz/hub-monorepo/tree/main/package
 
 - Write access to a hub (either your own, or a 3rd party hub)
 - An ETH wallet with about ~10$ USD of ETH bridged to [Optimism](https://www.optimism.io/)
-- An ETH RPC URL for OP Mainnet (e.g. via [Alchemy](https://www.alchemy.com/),[Infura](https://www.infura.io/) or [QuickNode](https://www.quicknode.com/)).
+- An ETH RPC URL for OP Mainnet (e.g. via [Alchemy](https://www.alchemy.com/), [Infura](https://www.infura.io/) or [QuickNode](https://www.quicknode.com/)).
 
 ## 1. Set up constants
 

--- a/docs/developers/guides/writing/verify-address.md
+++ b/docs/developers/guides/writing/verify-address.md
@@ -4,7 +4,7 @@
 
 - Write access to a hubble instance
 - Private key of an account key registered to an fid
-- An ethereum provider URL for OP Mainnet (e.g. via [Alchemy](https://www.alchemy.com/),[Infura](https://www.infura.io/) or [QuickNode](https://www.quicknode.com/)).
+- An ethereum provider URL for OP Mainnet (e.g. via [Alchemy](https://www.alchemy.com/), [Infura](https://www.infura.io/) or [QuickNode](https://www.quicknode.com/)).
 
 :::
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR fixes typos in Ethereum RPC URL descriptions across multiple developer guides.

### Detailed summary
- Corrected spacing in Ethereum RPC URL descriptions for OP Mainnet in various developer guides.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->