### PR TITLE
docs: Link to github from hubble.md

### DIFF
--- a/docs/hubble/hubble.md
+++ b/docs/hubble/hubble.md
@@ -1,6 +1,6 @@
 # Hubble
 
-Hubble is an implementation of the [Farcaster Hub Protocol](https://github.com/farcasterxyz/protocol), written
+[Hubble](https://github.com/farcasterxyz/hub-monorepo) is an implementation of the [Farcaster Hub Protocol](https://github.com/farcasterxyz/protocol), written
 in [TypeScript](https://www.typescriptlang.org/) and [Rust](https://www.rust-lang.org/).
 
 Hubble creates a private instance of Farcaster on your machine. It peers with other instances and downloads a copy of


### PR DESCRIPTION
Add a link to the Hubble github

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the link to the Hubble repository and adds the mention of Rust in the implementation languages.

### Detailed summary
- Updated link to the Hubble repository to `https://github.com/farcasterxyz/hub-monorepo`
- Added Rust as one of the implementation languages

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->