### PR TITLE
Small fixes in change-custody.md

### DIFF
--- a/docs/developers/guides/accounts/change-custody.md
+++ b/docs/developers/guides/accounts/change-custody.md
@@ -31,7 +31,7 @@ const signature = await eip712signer.signTransfer({
   deadline,
 });
 
-const { request: transferRequest } = await walletClient.simulateContract({
+const { request: transferRequest } = await publicClient.simulateContract({
   ...IdContract,
   functionName: 'transfer',
   args: [account, deadline, signature], // to, deadline, signature
@@ -84,7 +84,7 @@ export const readNonce = async () => {
   return await publicClient.readContract({
     address: ID_REGISTRY_ADDRESS,
     abi: idRegistryABI,
-    functionName: 'nonce',
+    functionName: 'nonces',
     args: [account],
   });
 };


### PR DESCRIPTION
 - `simulateContract` only works from a `publicClient`
 - the function on the Id Registry contract is `nonces`, not `nonce`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the function names in the `change-custody.md` file to align with the changes in the codebase.

### Detailed summary
- Updated function name from `nonce` to `nonces` in `readNonce` function.
- Replaced `walletClient` with `publicClient` in `simulateContract` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->