### PR TITLE
fix(docs): typo

### DIFF
--- a/docs/learn/architecture/contracts.md
+++ b/docs/learn/architecture/contracts.md
@@ -28,7 +28,7 @@ The IdRegistry lets users register, transfer and recover Farcaster accounts. An 
 
 ### Storage Registry
 
-The Storage Registry lets accounts rent [storage](../what-is-farcaster/messages.md#storage) by making a payment in Ethereum. The storage prices are set by admins in USD and converted to ETH using a Chainlink oracle. The price increases or decreases based on supply and demand.
+The Storage Registry lets accounts rent [storage](../what-is-farcaster/messages.md#storage) by making a payment in ETH. The storage prices are set by admins in USD and converted to ETH using a Chainlink oracle. The price increases or decreases based on supply and demand.
 
 ### Key Registry
 

--- a/docs/learn/what-is-farcaster/accounts.md
+++ b/docs/learn/what-is-farcaster/accounts.md
@@ -33,7 +33,7 @@ Users can set the recovery address to trusted services like Warpcast or they can
 - [IdRegistry](../../reference/contracts/reference/id-registry) - Lookup account data onchain.
 - [IdGateway](../../reference/contracts/reference/id-gateway) - Create accounts onchain.
 - [KeyRegistry](../../reference/contracts/reference/key-registry) - Lookup account key data onchain.
-- [KeyRegistry](../../reference/contracts/reference/key-gateway) - Create account keys onchain.
+- [KeyGateway](../../reference/contracts/reference/key-gateway) - Create account keys onchain.
 - [Get Farcaster Ids](../../reference/hubble/httpapi/fids) - Fetch a list of all registered account fids from a hub.
 - [Get account keys](../../reference/hubble/httpapi/onchain#onchainsignersbyfid) - Fetch the account keys (signers) for an account from a hub.
 


### PR DESCRIPTION
by convention Ethereum is the name of protocol, and Ether more commonly called ETH is the name of currency

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation to reflect that payments for storage in the Storage Registry are made in ETH, not USD.

### Detailed summary
- Updated payment currency in Storage Registry from Ethereum to ETH.
- Renamed `KeyRegistry` to `KeyGateway` in `accounts.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->