### PR TITLE
Add reference for power badge endpoint

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -404,7 +404,7 @@ export default defineConfig({
         {
           text: 'Warpcast',
           items: [
-            { text: 'Channel APIs', link: '/reference/warpcast/api' },
+            { text: 'APIs', link: '/reference/warpcast/api' },
             { text: 'Cast Intents', link: '/reference/warpcast/cast-composer-intents' },
             { text: 'Embeds', link: '/reference/warpcast/embeds' },
           ],

--- a/docs/reference/warpcast/api.md
+++ b/docs/reference/warpcast/api.md
@@ -6,7 +6,7 @@ Warpcast has the concept of channels which build upon FIP-2 (setting parentUrl t
 You can read more about channels in the [documentation](https://www.notion.so/warpcast/Channels-4f249d22575348a5a0488b5d86f0dd1c?pvs=4).
 
 This endpoint provides metadata around all the channels in Warpcast. The endpoint requires no authentication,
-does not use any parameters and does not pagination.
+does not use any parameters and does not paginate.
 
 ```bash
 curl https://api.warpcast.com/v2/all-channels | jq
@@ -35,3 +35,27 @@ Properties:
 - `imageUrl` - URL to the channel avatar
 - `loadFid` - The fid of the user who created the channel, if present (called 'Host' in Warpcast)
 - `createdAt` - UNIX time when channel was created, in seconds
+
+<br/>
+
+### Get All Power Badge Users
+
+Warpcast grants power badges to users who are active, interesting to others and not spammy. 
+You can read more about power badges in the [documentation](https://warpcast.notion.site/Power-Badge-d81fea2e953e4dafae7c85295ffaf3ae).
+
+This endpoint provides the list of all users who currently hold a power badge. The endpoint requires no authentication,
+does not use any parameters and does not paginate.
+
+```bash
+curl https://api.warpcast.com/v2/power-badge-users | jq
+```
+
+The return object is a JSON array with fids of users who currently hold a power badge:
+
+```json
+{
+  "fids": [1, 2, 3]
+},
+```
+
+Warpcast recalculates badge ownership once every week, on Tuesdays at 12:00:00 UTC.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the Warpcast documentation by adding a new endpoint to retrieve users with power badges.

### Detailed summary
- Renamed a section in the documentation config file
- Added a new endpoint to retrieve users with power badges
- Updated information about power badges and their calculation schedule

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->