### PR TITLE
Add link to Frames Errors proposal in upcoming

### DIFF
--- a/docs/reference/frames/spec.md
+++ b/docs/reference/frames/spec.md
@@ -429,3 +429,4 @@ The following ideas are being explored actively as extensions to the frame speci
 - A refresh period, to bust the cache for the original frame url.
 - An authentication system, to let users log into other applications via frames.
 - A JSON response type, to allow for more flexibility in frame responses.
+- [A light-weight way for frames to surface application errors to users](https://warpcast.notion.site/Frames-Errors-ddc965b097d44d9ea03ddf98498597c6?pvs=74)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a light-weight way for frames to surface application errors to users.

### Detailed summary
- Added a light-weight way for frames to surface application errors to users through a link to a Notion page.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->