### PR TITLE
Add fc-devs link to troubleshooting.md

### DIFF
--- a/docs/hubble/troubleshooting.md
+++ b/docs/hubble/troubleshooting.md
@@ -51,7 +51,8 @@ BOOTSTRAP_NODE=/dns/hoyt.farcaster.xyz/tcp/2282
 Use the [grafana dashboard](/hubble/monitoring) to monitor your hub. The Status tab will show the message sync
 percent of your hub compared to it's peers. If this is less than 100%, try restarting the hub and waiting a while. If
 this
-persists, reach out on the [Developer Chat](https://t.me/farcasterdevchat) or file an issue on
+persists, reach out on the [fc-devs channel](https://warpcast.com/~/channel/fc-devs), 
+the [Developer Chat telegram](https://t.me/farcasterdevchat) or file an issue on
 the [hub repo](https://github.com/farcasterxyz/hub-monorepo/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=bug%20%28hubble%29%3A).
 
 ## Managing your Peer ID


### PR DESCRIPTION
Added a link to the fc-devs channel as an alternative help location. 
Background:
I was looking to do some debugging on an issue I am having with the Hubble grafana and when I went to telegram group, I saw I couldn't post. One of the recent comments recommended people post in the fc-devs channel on Farcaster instead. I figured updating the docs with this link would be good.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the troubleshooting guide in `docs/hubble/troubleshooting.md` to provide more specific instructions for reaching out for help.

### Detailed summary
- Updated the link for reaching out to the developer community to [fc-devs channel](https://warpcast.com/~/channel/fc-devs)
- Added a reference to the Developer Chat telegram for assistance
- Updated the link for filing an issue on the hub repository

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->