### PR TITLE
chore: add supported chains to frames docs

### DIFF
--- a/docs/reference/frames/spec.md
+++ b/docs/reference/frames/spec.md
@@ -191,6 +191,16 @@ type TransactionTargetResponse {
 }
 ```
 
+**Supported Chains**
+
+| Network      | Chain ID         |
+| ------------ | ---------------- |
+| Ethereum     | `eip155:1`       |
+| Optimism     | `eip155:10`      |
+| Base         | `eip155:8453`    |
+| Zora         | `eip155:7777777` |
+| Base Sepolia | `eip155:84532`   |
+
 **Ethereum Params**
 
 If the method is `eth_sendTransaction` and the chain is an Ethereum EVM chain, the param must be of type `EthSendTransactionParams`:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a section on supported chains to the spec.md file, specifying chain IDs for different networks. Additionally, it outlines the required parameter type for `eth_sendTransaction` on Ethereum EVM chains.

### Detailed summary
- Added a section on supported chains with chain IDs for Ethereum, Optimism, Base, Zora, and Base Sepolia
- Specified the required parameter type `EthSendTransactionParams` for `eth_sendTransaction` on Ethereum EVM chains

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->