### PR TITLE
Update status.md with new data type

### DIFF
--- a/docs/auth-kit/client/app/status.md
+++ b/docs/auth-kit/client/app/status.md
@@ -24,17 +24,21 @@ const status = await appClient.status({
 {
     response: Response
     data: {
-        state: 'pending' | 'completed'
-        nonce: string
-        message?: string
-        signature?: Hex
-        fid?: number
-        username?: string
-        bio?: string
-        displayName?: string
-        pfpUrl?: string
-        custody?: Hex;
-        verifications?: Hex[];
+      state: "pending";
+      nonce: string;
+    } | {
+      state: "completed";
+      nonce: string;
+      url: string;
+      message: string;
+      signature: `0x${string}`;
+      fid: number;
+      username?: string;
+      bio?: string;
+      displayName?: string;
+      pfpUrl?: string;
+      verifications?: Hex[];
+      custody?: Hex;
     }
     isError: boolean
     error: Error


### PR DESCRIPTION
This doc update is linked to [this PR](https://github.com/farcasterxyz/auth-monorepo/pull/161) 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the structure of the `data` object in the `status.md` file within the auth-kit client app to have separate shapes for "pending" and "completed" states.

### Detailed summary
- Separated `data` object into two shapes: "pending" and "completed"
- Added `url`, `message`, `signature`, `fid` fields for "completed" state
- Updated `state` field to be a string literal for both shapes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->