### PR TITLE
Document cli arguments to set network

### DIFF
--- a/docs/hubble/networks.md
+++ b/docs/hubble/networks.md
@@ -16,9 +16,16 @@ Testnet is a sandbox environment for developers to test new features. Dummy mess
 Set the following variables in your .env file in `apps/hubble`:
 
 ```sh
-
 FC_NETWORK_ID=2
 BOOTSTRAP_NODE=/dns/testnet1.farcaster.xyz/tcp/2282
+```
+
+If running from source code, add these arguments to the `yarn start` command
+
+```sh
+yarn start ... \
+    -n 2 \
+    -b /dns/testnet1.farcaster.xyz/tcp/2282
 ```
 
 ## Mainnet
@@ -30,4 +37,12 @@ Set the following variables in your .env file in `apps/hubble`:
 ```sh
 FC_NETWORK_ID=1
 BOOTSTRAP_NODE=/dns/nemes.farcaster.xyz/tcp/2282
+```
+
+If running from source code, add these arguments to the `yarn start` command
+
+```sh
+yarn start ... \
+    -n 1 \
+    -b /dns/nemes.farcaster.xyz/tcp/2282
 ```


### PR DESCRIPTION
Under `Installing from source` in the hubble install page, we reference the networks page to configure which network and bootstrap server. Originally the networks page only showed how to configure the .env file which docker uses, not the "from source" method.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `networks.md` file in the documentation to include instructions for running the source code with specific network configurations.

### Detailed summary
- Added instructions for running source code with network configurations for `FC_NETWORK_ID=2` and `FC_NETWORK_ID=1`
- Included arguments for `yarn start` command to specify network ID and bootstrap node address

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->