### PR TITLE
fix parameter name for useProfile

### DIFF
--- a/docs/auth-kit/installation.md
+++ b/docs/auth-kit/installation.md
@@ -56,7 +56,7 @@ import { useProfile } from '@farcaster/auth-kit';
 export const UserProfile = () => {
   const {
     isAuthenticated,
-    userData: { username, fid },
+    profile: { username, fid },
   } = useProfile();
   return (
     <div>


### PR DESCRIPTION
useProfile hook will only return 'profile', this pr is to fix the error in the docs.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `installation.md` file in the `auth-kit` documentation. It changes the destructured object key from `userData` to `profile` in the `useProfile` hook.

### Detailed summary
- Updated object key from `userData` to `profile` in the `useProfile` hook assignment.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->