### PR TITLE
Adding service providers to AuthKit

### DIFF
--- a/docs/auth-kit/service-providers.md
+++ b/docs/auth-kit/service-providers.md
@@ -1,0 +1,13 @@
+# Overview
+
+In addition to the core AuthKit implementation, "Sign in With Farcaster" can be implemented through multiple service providers and combined with additional functionality and login methods.
+
+# Providers
+
+Below is a list of providers that currently support "Sign in With Farcaster" functionality as part of their product suite.
+
+- [Dynamic](https://docs.dynamic.xyz/guides/integrations/sign-in-with-farcaster)
+- [Neynar](https://docs.neynar.com/docs/how-to-let-users-connect-farcaster-accounts-with-write-access-for-free-using-sign-in-with-neynar-siwn)
+- [Privy](https://docs.privy.io/guide/react/recipes/misc/farcaster)
+- [Web3auth](https://web3auth.io/docs/guides/farcaster-sfa-web)
+- [ThirdWeb](https://github.com/thirdweb-example/thirdweb-siwf)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add an overview and list of service providers supporting "Sign in With Farcaster" in the `service-providers.md` file.

### Detailed summary
- Added an overview section for "Sign in With Farcaster" implementation.
- Listed service providers supporting the functionality with their respective links.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->