### PR TITLE
fix: typo on accounts page

### DIFF
--- a/docs/learn/what-is-farcaster/accounts.md
+++ b/docs/learn/what-is-farcaster/accounts.md
@@ -33,7 +33,7 @@ Users can set the recovery address to trusted services like Warpcast or they can
 - [IdRegistry](../../reference/contracts/reference/id-registry) - Lookup account data onchain.
 - [IdGateway](../../reference/contracts/reference/id-gateway) - Create accounts onchain.
 - [KeyRegistry](../../reference/contracts/reference/key-registry) - Lookup account key data onchain.
-- [KeyRegistry](../../reference/contracts/reference/key-gateway) - Create account keys onchain.
+- [KeyGateway](../../reference/contracts/reference/key-gateway) - Create account keys onchain.
 - [Get Farcaster Ids](../../reference/hubble/httpapi/fids) - Fetch a list of all registered account fids from a hub.
 - [Get account keys](../../reference/hubble/httpapi/onchain#onchainsignersbyfid) - Fetch the account keys (signers) for an account from a hub.
 


### PR DESCRIPTION
Noticed a typo where "Key Registry" should read "Key Gateway"

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `accounts.md` file in the Farcaster documentation to correct a reference to `KeyRegistry` and replace it with `KeyGateway`.

### Detailed summary
- Updated reference from `KeyRegistry` to `KeyGateway` for creating account keys onchain.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->