### PR TITLE
feat: add arbitrum and gnosis chain ids

### DIFF
--- a/docs/reference/frames/spec.md
+++ b/docs/reference/frames/spec.md
@@ -196,11 +196,13 @@ type TransactionTargetResponse {
 | Network      | Chain ID           |
 | ------------ | ------------------ |
 | Ethereum     | `eip155:1`         |
-| Optimism     | `eip155:10`        |
+| Arbitrum     | `eip155:42161`     |
 | Base         | `eip155:8453`      |
-| Zora         | `eip155:7777777`   |
-| Degen        | `eip155:666666666` |
 | Base Sepolia | `eip155:84532`     |
+| Degen        | `eip155:666666666` |
+| Gnosis       | `eip155:100`       |
+| Optimism     | `eip155:10`        |
+| Zora         | `eip155:7777777`   |
 
 **Ethereum Params**
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the Ethereum frame specifications with new EIP155 values for Arbitrum, Gnosis, and Degen.

### Detailed summary
- Updated `Arbitrum` EIP155 to `42161`
- Added `Gnosis` with EIP155 `100`
- Restored previous values for `Optimism`, `Zora`, and `Degen`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->