### PR TITLE
Update docs about Replicator to mention shuttle

### DIFF
--- a/docs/developers/guides/apps/replicate.md
+++ b/docs/developers/guides/apps/replicate.md
@@ -6,52 +6,10 @@
 
 :::
 
-While some applications can be written by directly querying hubble, most serious applications need to access the data
+While some applications can be written by directly querying Hubble, most serious applications need to access the data
 in a more structured way.
 
-Hubble comes with a [replication app](https://github.com/farcasterxyz/hub-monorepo/tree/main/apps/replicator) that can
+[Shuttle](https://github.com/farcasterxyz/hub-monorepo/tree/main/packages/shuttle) is a package
 be used to mirror Hubble's data to a Postgres DB for convenient access to the underlying data.
 
-## Installation
-
-```bash
-# Run the following script and answer the prompts
-curl -sSL https://download.farcaster.xyz/bootstrap-replicator.sh | bash
-```
-
-Once the Docker images have finished downloading, you should start to see messages like:
-
-```
-[13:24:18.141] INFO (73940): Backfill 13.42% complete. Estimated time remaining: 46 minutes, 41 seconds
-[13:24:23.228] INFO (73940): Backfill 13.52% complete. Estimated time remaining: 46 minutes, 50 seconds
-[13:24:28.389] INFO (73940): Backfill 13.60% complete. Estimated time remaining: 47 minutes, 3 seconds
-[13:24:33.502] INFO (73940): Backfill 13.71% complete. Estimated time remaining: 47 minutes, 10 seconds
-```
-
-First time sync can take a couple of hours to a day, depending on how powerful your machine is.
-
-## Connecting to postgres
-
-```bash
-cd ~/replicator
-# Via docker
-docker compose exec postgres psql -U replicator replicator
-# Or directly, using the default port for the replicator docker container
-psql -U replicator -h localhost -p 6541 replicator
-```
-
-## Querying the data
-
-Get the 10 most recents casts for a user
-
-```sql
-select timestamp, text, mentions, mentions_positions, embeds
-from casts
-where fid = 1
-order by timestamp desc
-limit 10;
-```
-
-## Schema
-
-For more information on the schema, see the [replicator schema](/reference/replicator/schema).
+Check out the documentation for more information.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the replication app documentation, replacing references to Hubble with Shuttle and simplifying installation instructions.

### Detailed summary
- Replaced references to Hubble with Shuttle throughout the document.
- Simplified installation instructions by removing the script and Docker setup details.
- Removed specific querying and schema details, directing users to the documentation for more information.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->