### PR TITLE
Note that frameUrl is a 256-byte string.

### DIFF
--- a/docs/reference/actions/spec.md
+++ b/docs/reference/actions/spec.md
@@ -98,10 +98,10 @@ An action server may return 200 OK and a JSON body in the following format to di
 
 **Properties**
 
-| Key        | Description                                                                                                  |
-| ---------- | ------------------------------------------------------------------------------------------------------------ |
-| `type`     | Must be `frame`.                                                                                             |
-| `frameUrl` | URL of the frame to display. Clients must show the frame in a special context, like a modal or bottom sheet. |
+| Key        | Description                                                                                                                   |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `type`     | Must be `frame`.                                                                                                              |
+| `frameUrl` | URL of the frame to display. 256-byte string. Clients must show the frame in a special context, like a modal or bottom sheet. |
 
 ### Error response type
 


### PR DESCRIPTION
I have an Action that returns a Frame and I had a long URL with querystring params in `frameUrl` and the frame was never loading because it wasn't clear to me that `frameUrl` was limited to 256 characters. Hoping this will help someone else avoid the same issue.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `frameUrl` property description in `spec.md` to specify that it should be a 256-byte string.

### Detailed summary
- Updated `frameUrl` property description to specify it should be a 256-byte string.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->