### PR TITLE
Edit: Wrong word (urls)

### DIFF
--- a/docs/learn/contributing/overview.md
+++ b/docs/learn/contributing/overview.md
@@ -13,7 +13,7 @@ To get involved, try looking up open issues in one of the repos below or join a 
 | [Contracts](https://github.com/farcasterxyz/contracts)           | The canonical Farcaster contracts            |
 | [Hubble](https://github.com/farcasterxyz/hub-monorepo)           | A Farcaster Hub written in Rust + Typescript |
 | [FName Registry](https://github.com/farcasterxyz/fname-registry) | The canonical server to register fnames      |
-| [Docs](https://github.com/farcasterxyz/www)                      | Documentation for all the above (this site)  |
+| [Docs](https://github.com/farcasterxyz/docs)                     | Documentation for all the above (this site)  |
 
 ## Documentation
 


### PR DESCRIPTION
**Edit: Wrong word (urls)**

![image](https://github.com/farcasterxyz/docs/assets/106298826/fcbb65be-e606-4c93-92ff-7ac553b795ad)



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the link to the documentation repository in the overview.md file of the contributing guide.

### Detailed summary
- Updated the link to the documentation repository in the overview.md file from `https://github.com/farcasterxyz/www` to `https://github.com/farcasterxyz/docs`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->