### PR TITLE
Updated example response to align with protocol spec

### DIFF
--- a/docs/reference/fname/api.md
+++ b/docs/reference/fname/api.md
@@ -48,20 +48,22 @@ value
 curl https://fnames.farcaster.xyz/transfers?fid=1 | jq
 ```
 
-Both will return the same transfer object:
+Both will return the same transfers object:
 
 ```json
 {
-  "transfer": {
-    "id": 1,
-    "timestamp": 1628882891,
-    "username": "farcaster",
-    "owner": "0x8773442740c17c9d0f0b87022c722f9a136206ed",
-    "from": 0,
-    "to": 1,
-    "user_signature": "0xa6fdd2a69deab5633636f32a30a54b21b27dff123e6481532746eadca18cd84048488a98ca4aaf90f4d29b7e181c4540b360ba0721b928e50ffcd495734ef8471b",
-    "server_signature": "0xb7181760f14eda0028e0b647ff15f45235526ced3b4ae07fcce06141b73d32960d3253776e62f761363fb8137087192047763f4af838950a96f3885f3c2289c41b"
-  }
+    "transfers": [
+        {
+            "id": 1,
+            "timestamp": 1628882891,
+            "username": "farcaster",
+            "owner": "0x8773442740c17c9d0f0b87022c722f9a136206ed",
+            "from": 0,
+            "to": 1,
+            "user_signature": "0xa6fdd2a69deab5633636f32a30a54b21b27dff123e6481532746eadca18cd84048488a98ca4aaf90f4d29b7e181c4540b360ba0721b928e50ffcd495734ef8471b",
+            "server_signature": "0xb7181760f14eda0028e0b647ff15f45235526ced3b4ae07fcce06141b73d32960d3253776e62f761363fb8137087192047763f4af838950a96f3885f3c2289c41b"
+        }
+    ]
 }
 ```
 


### PR DESCRIPTION
Updated example response to align with
https://github.com/farcasterxyz/protocol/blob/main/docs/SPECIFICATION.md#5-fname-specifications

Replaced response key  "transfer" (object) with "transfers" (array of objects)

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the API documentation to reflect the change from returning a single `transfer` object to an array of `transfers`.

### Detailed summary
- Updated API documentation to reflect the change from returning a single `transfer` object to an array of `transfers`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->