### PR TITLE
doc: Fix method name typo in signed-key-request-validator.md

### DIFF
--- a/docs/reference/contracts/reference/signed-key-request-validator.md
+++ b/docs/reference/contracts/reference/signed-key-request-validator.md
@@ -54,7 +54,7 @@ const deadline = getDeadline();
 // The getSignedKeyRequestMetadata helper generates a SignedKeyRequest
 // signature and returns an ABI-encoded SignedKeyRequest metadata struct.
 const eip712Signer = new ViemLocalEip712Signer(appAccount);
-const encodedData = await eip712Signer.getSigneKeyRequestMetadata({
+const encodedData = await eip712Signer.getSignedKeyRequestMetadata({
   requestFid: 9152n,
   key,
   deadline,


### PR DESCRIPTION
The method that is called in the doc should be `getSignedKeyRequestMetadata` but not `getSigneKeyRequestMetadata`

Reference:
[1] source code: https://github.com/farcasterxyz/hub-monorepo/blob/eacf29c98cdc81fcb614a8e7ae4dbedf889f15da/packages/core/src/signers/eip712Signer.ts#L44

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates a method name in `signed-key-request-validator.md` file from `getSigneKeyRequestMetadata` to `getSignedKeyRequestMetadata`.

### Detailed summary
- Updated method name from `getSigneKeyRequestMetadata` to `getSignedKeyRequestMetadata` in `signed-key-request-validator.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->