### PR TITLE
Accidentally a word

### DIFF
--- a/docs/reference/frames/spec.md
+++ b/docs/reference/frames/spec.md
@@ -236,7 +236,7 @@ There are a few rules for serving images in `fc:frame:image` tags:
 - The type of image must be jpg, png or gif.
 - The image source must either be an external resource with content headers or a data URI.
 
-Clients may resize larger images or crop those that do not fit in their aspect ratio. SVG images are not because they can contain scripts and extra work must be done by clients to sanitize them.
+Clients may resize larger images or crop those that do not fit in their aspect ratio. SVG images are not allowed because they can contain scripts and extra work must be done by clients to sanitize them.
 
 Frame servers can use cache headers to refresh images and offer more dynamic first frame experiences:
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to clarify that SVG images are not allowed due to security concerns. Additionally, it mentions the use of cache headers for frame servers.

### Detailed summary
- Clarified that SVG images are not allowed due to security risks
- Mentioned the use of cache headers for frame servers

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->