### PR TITLE
change hub reward section

### DIFF
--- a/docs/learn/architecture/hubs.md
+++ b/docs/learn/architecture/hubs.md
@@ -58,4 +58,4 @@ You may need a Hub if you are building an app that wants to read or write Farcas
 
 **2. Are there rewards for running a Hub?**
 
-Farcaster does not provide rewards for Hubs and does not plan to. Warpcast, a company building on Farcaster, gives Hub runners minor rewards but may change this in the future.
+Farcaster does not provide rewards for Hubs and does not plan to. Warpcast, a company building on Farcaster, has stopped providing small rewards for running a Hub.

--- a/docs/learn/architecture/hubs.md
+++ b/docs/learn/architecture/hubs.md
@@ -58,4 +58,4 @@ You may need a Hub if you are building an app that wants to read or write Farcas
 
 **2. Are there rewards for running a Hub?**
 
-Farcaster does not provide rewards for Hubs and does not plan to. Warpcast, a company building on Farcaster, has stopped providing small rewards for running a Hub.
+Farcaster does not provide rewards for Hubs and does not plan to.


### PR DESCRIPTION
remove hub rewards mentioned by Warpcast, since they are not given anymore

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the mention of Warpcast giving rewards to Hub runners in the `hubs.md` file.

### Detailed summary
- Removed the mention of Warpcast giving rewards to Hub runners in `docs/learn/architecture/hubs.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->