### PR TITLE
docs: clarify and expand FAQ on app FIDs

### DIFF
--- a/docs/reference/contracts/faq.md
+++ b/docs/reference/contracts/faq.md
@@ -54,4 +54,14 @@ Call the [`keysOf`](https://optimistic.etherscan.io/address/0x00000000fc1237824f
 
 ### What is an app fid? How do I get one?
 
-An "app fid" is no different than any other Farcaster ID: it just represents an application rather than an individual user. You can register an app fid directly through the [Bundler](/reference/contracts/reference/bundler.md) or [IdGateway](/reference/contracts/reference/id-gateway.md), or use a Farcaster client to register an account for your app. Since you'll need to sign [key request metadata](/reference/contracts/reference/signed-key-request-validator.md) from the wallet that owns your app fid, keep the private key secure.
+**What is an FID?**
+
+An FID (Farcaster ID) is a unique identifier used to distinguish applications and users. With an FID, apps and users can be identified and differentiated.
+
+**Why is an FID necessary?**
+
+To create or post anything on the Farcaster platform, an FID is essential for identifying your app or user.
+
+**How do I get one?**
+
+You can register an app fid directly through the [Bundler](/reference/contracts/reference/bundler.md) or [IdGateway](/reference/contracts/reference/id-gateway.md), or use a Farcaster client to register an account for your app. Since you'll need to sign [key request metadata](/reference/contracts/reference/signed-key-request-validator.md) from the wallet that owns your app fid, keep the private key secure.


### PR DESCRIPTION
As a beginner, I found the current FAQ section on app FIDs a bit confusing. I think it would be more helpful if it included:

- A clear definition of what an FID is
- An explanation of why FIDs are necessary
- A step-by-step guide on how to register an app fid

These changes would make it easier for new users, like myself, to understand why FIDs are important and how to get one for our applications.

Closes #243

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to clarify the concept of FID (Farcaster ID) and its importance in distinguishing applications and users.

### Detailed summary
- Updated explanation of what an FID is
- Added clarification on why an FID is necessary
- Revised information on how to obtain an app FID

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->