### PR TITLE
Add channelKey and parentCastHash to cast intent docs

### DIFF
--- a/docs/reference/warpcast/cast-composer-intents.md
+++ b/docs/reference/warpcast/cast-composer-intents.md
@@ -20,6 +20,19 @@ https://warpcast.com/~/compose?text=Hello%20world!&embeds[]=https://farcaster.xy
 https://warpcast.com/~/compose?text=Hello%20@farcaster!&embeds[]=https://farcaster.xyz&embeds[]=https://github.com/farcasterxyz/protocol
 ```
 
+#### Compose with cast text on a specific channel
+
+```bash
+https://warpcast.com/~/compose?text=Hello%20world!&channelKey=farcaster
+```
+
+#### Reply with cast text, to a cast with hash
+
+```bash
+https://warpcast.com/~/compose?text=Looks%20good!&parentCastHash=0x09455067393562d3296bcbc2ec1c2d6bba8ac1f1
+```
+
+
 #### Additional details
 
 - Embeds are any valid URLs

--- a/docs/reference/warpcast/cast-composer-intents.md
+++ b/docs/reference/warpcast/cast-composer-intents.md
@@ -26,7 +26,7 @@ https://warpcast.com/~/compose?text=Hello%20@farcaster!&embeds[]=https://farcast
 https://warpcast.com/~/compose?text=Hello%20world!&channelKey=farcaster
 ```
 
-#### Reply with cast text, to a cast with hash
+#### Reply with cast text to a cast with hash
 
 ```bash
 https://warpcast.com/~/compose?text=Looks%20good!&parentCastHash=0x09455067393562d3296bcbc2ec1c2d6bba8ac1f1


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to add new examples for composing cast text on a specific channel and replying with cast text to a cast with a hash on Warpcast.

### Detailed summary
- Added example for composing with cast text on a specific channel
- Added example for replying with cast text to a cast with hash on Warpcast

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->