### PR TITLE
fix typo

### DIFF
--- a/docs/reference/frames/spec.md
+++ b/docs/reference/frames/spec.md
@@ -212,7 +212,7 @@ See [EIP-712](https://eips.ethereum.org/EIPS/eip-712).
     - `domain`: the typed domain
     - `types`: the type definitions for the typed data
     - `primaryType`: the primary type to extract from types and use in value.
-    - `message`: type typed message
+    - `message`: typed message
 
 ```ts
 type EthSignTypedDataV4Action = {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the `message` type definition in `docs/reference/frames/spec.md`.

### Detailed summary
- Updated `message` type definition from `type typed message` to `typed message` in `docs/reference/frames/spec.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->