### PR TITLE
include address that completed wallet action on target post back

### DIFF
--- a/docs/reference/frames/spec.md
+++ b/docs/reference/frames/spec.md
@@ -171,7 +171,7 @@ First, the client makes a POST request to the `target` URL to fetch data about t
 }
 ```
 
-The client uses this data to request an action in the user's wallet. If the user signs completes the action, the client makes a POST request to the `post_url` with a Signature Packet that includes the transaction or signature hash. The frame server must respond with a 200 OK and another frame. The frame server may monitor the transaction hash to determine if the transaction succeeds, reverts, or times out.
+The client uses this data to request an action in the user's wallet. If the user completes the action, the client makes a POST request to the `post_url` with a Signature Packet that includes the transaction or signature hash in `transaction_id` and the address used in `address`. The frame server must respond with a 200 OK and another frame. The frame server may monitor the transaction hash to determine if the transaction succeeds, reverts, or times out.
 
 #### Wallet Action Response Type
 
@@ -456,6 +456,8 @@ Although it may be possible to validate an Ed25519 signature onchain, a valid si
 
 | Date    | Change                                                                                                                                                                                          |
 | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 7/10/24 | Frames should include the address that took a wallet action when posting back to target.
+| 7/10/24 | Frames can request [EIP-712 signatures](https://www.notion.so/warpcast/Frames-Wallet-Signatures-debe97a82e2643d094d4088f1badd791?pm=c).                                                     |
 | 3/25/24 | Frames can surface [application-level errors](https://warpcast.notion.site/Frames-Errors-ddc965b097d44d9ea03ddf98498597c6?pvs=74) to users.                                                     |
 | 3/8/24  | Frames can request [transactions](https://www.notion.so/warpcast/Frame-Transactions-Public-9d9f9f4f527249519a41bd8d16165f73#c1c3182208ce4ae4a7ffa72129b9795a) from the user's connected wallet. |
 | 2/25/24 | Frames can pass [state](https://www.notion.so/warpcast/Frames-State-Public-f3de69c1d12944e583a37204c98d25d9) to the frame server.                                                               |


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the `spec.md` file by specifying the address and transaction ID in the Signature Packet and adding support for EIP-712 signatures.

### Detailed summary
- Added `address` and `transaction_id` fields in Signature Packet
- Frames can now request EIP-712 signatures

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->