### PR TITLE
deprecate nemes for hoyt.

### DIFF
--- a/docs/developers/guides/apps/feed.md
+++ b/docs/developers/guides/apps/feed.md
@@ -24,7 +24,7 @@ import { getSSLHubRpcClient } from '@farcaster/hub-nodejs';
  * Populate the following constants with your own values
  */
 
-const HUB_URL = 'nemes.farcaster.xyz:2283'; // URL of the Hub
+const HUB_URL = 'hoyt.farcaster.xyz:2283'; // URL of the Hub
 const FIDS = [2, 3]; // User IDs to fetch casts for
 
 // const client = getInsecureHubRpcClient(HUB_URL); // Use this if you're not using SSL

--- a/docs/developers/guides/basics/hello-world.md
+++ b/docs/developers/guides/basics/hello-world.md
@@ -42,9 +42,9 @@ const OP_PROVIDER_URL = '<REQUIRED>'; // Alchemy or Infura url
 const RECOVERY_ADDRESS = zeroAddress; // Optional, using the default value means the account will not be recoverable later if the mnemonic is lost
 const ACCOUNT_KEY_PRIVATE_KEY: Hex = zeroAddress; // Optional, using the default means a new account key will be created each time
 
-// Note: nemes is the Farcaster team's mainnet hub, which is password protected to prevent abuse. Use a 3rd party hub
+// Note: hoyt is the Farcaster team's mainnet hub, which is password protected to prevent abuse. Use a 3rd party hub
 // provider like https://neynar.com/ Or, run your own mainnet hub and broadcast to it permissionlessly.
-const HUB_URL = 'nemes.farcaster.xyz:2283'; // URL + Port of the Hub
+const HUB_URL = 'hoyt.farcaster.xyz:2283'; // URL + Port of the Hub
 const HUB_USERNAME = ''; // Username for auth, leave blank if not using TLS
 const HUB_PASS = ''; // Password for auth, leave blank if not using TLS
 const USE_SSL = false; // set to true if talking to a hub that uses SSL (3rd party hosted hubs or hubs that require auth)

--- a/docs/hubble/networks.md
+++ b/docs/hubble/networks.md
@@ -36,7 +36,7 @@ Set the following variables in your .env file in `apps/hubble`:
 
 ```sh
 FC_NETWORK_ID=1
-BOOTSTRAP_NODE=/dns/nemes.farcaster.xyz/tcp/2282
+BOOTSTRAP_NODE=/dns/hoyt.farcaster.xyz/tcp/2282
 ```
 
 If running from source code, add these arguments to the `yarn start` command
@@ -44,5 +44,5 @@ If running from source code, add these arguments to the `yarn start` command
 ```sh
 yarn start ... \
     -n 1 \
-    -b /dns/nemes.farcaster.xyz/tcp/2282
+    -b /dns/hoyt.farcaster.xyz/tcp/2282
 ```

--- a/docs/reference/hubble/datatypes/events.md
+++ b/docs/reference/hubble/datatypes/events.md
@@ -12,7 +12,7 @@ Hubble keeps event around for 3 days after which they are deleted to save space.
 | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ----------- |
 | type  | [HubEventType](#HubEventType)                                                                                                                                                                                                               |       |             |
 | id    | [uint64](#uint64)                                                                                                                                                                                                                           |       |             |
-| body  | [MergeMessageBody](#mergemessagebody), <br> [PruneMessageBody](#prunemessagebody), <br> [RevokeMessageBody](#revokemessagebody), <br>[MergeUserNameProofBody](#mergeusernameproofbody), <br>[MergeOnChainEventBody](#mergeonchaineventbody) | oneOf |             |
+| body  | [MergeMessageBody](#mergemessagebody), <br> [PruhoytsageBody](#pruhoytsagebody), <br> [RevokeMessageBody](#revokemessagebody), <br>[MergeUserNameProofBody](#mergeusernameproofbody), <br>[MergeOnChainEventBody](#mergeonchaineventbody) | oneOf |             |
 
 ## HubEventType
 
@@ -45,9 +45,9 @@ Hubble keeps event around for 3 days after which they are deleted to save space.
 | username_proof_message         | [Message](#Message)             |       |             |
 | deleted_username_proof_message | [Message](#Message)             |       |             |
 
-<a name="-PruneMessageBody"></a>
+<a name="-PruhoytsageBody"></a>
 
-## PruneMessageBody
+## PruhoytsageBody
 
 | Field   | Type                | Label | Description |
 | ------- | ------------------- | ----- | ----------- |

--- a/docs/reference/hubble/datatypes/events.md
+++ b/docs/reference/hubble/datatypes/events.md
@@ -12,7 +12,7 @@ Hubble keeps event around for 3 days after which they are deleted to save space.
 | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ----------- |
 | type  | [HubEventType](#HubEventType)                                                                                                                                                                                                               |       |             |
 | id    | [uint64](#uint64)                                                                                                                                                                                                                           |       |             |
-| body  | [MergeMessageBody](#mergemessagebody), <br> [prunemessagebody](#PruneMessageBody), <br> [RevokeMessageBody](#revokemessagebody), <br>[MergeUserNameProofBody](#mergeusernameproofbody), <br>[MergeOnChainEventBody](#mergeonchaineventbody) | oneOf |             |
+| body  | [MergeMessageBody](#mergemessagebody), <br> [PruneMessageBody](#prunemessagebody), <br> [RevokeMessageBody](#revokemessagebody), <br>[MergeUserNameProofBody](#mergeusernameproofbody), <br>[MergeOnChainEventBody](#mergeonchaineventbody) | oneOf |             |
 
 ## HubEventType
 

--- a/docs/reference/hubble/datatypes/events.md
+++ b/docs/reference/hubble/datatypes/events.md
@@ -12,7 +12,7 @@ Hubble keeps event around for 3 days after which they are deleted to save space.
 | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ----------- |
 | type  | [HubEventType](#HubEventType)                                                                                                                                                                                                               |       |             |
 | id    | [uint64](#uint64)                                                                                                                                                                                                                           |       |             |
-| body  | [MergeMessageBody](#mergemessagebody), <br> [PruneMessageBody](#PruneMessageBody), <br> [RevokeMessageBody](#revokemessagebody), <br>[MergeUserNameProofBody](#mergeusernameproofbody), <br>[MergeOnChainEventBody](#mergeonchaineventbody) | oneOf |             |
+| body  | [MergeMessageBody](#mergemessagebody), <br> [prunemessagebody](#PruneMessageBody), <br> [RevokeMessageBody](#revokemessagebody), <br>[MergeUserNameProofBody](#mergeusernameproofbody), <br>[MergeOnChainEventBody](#mergeonchaineventbody) | oneOf |             |
 
 ## HubEventType
 

--- a/docs/reference/hubble/datatypes/events.md
+++ b/docs/reference/hubble/datatypes/events.md
@@ -12,7 +12,7 @@ Hubble keeps event around for 3 days after which they are deleted to save space.
 | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ----------- |
 | type  | [HubEventType](#HubEventType)                                                                                                                                                                                                               |       |             |
 | id    | [uint64](#uint64)                                                                                                                                                                                                                           |       |             |
-| body  | [MergeMessageBody](#mergemessagebody), <br> [PruhoytsageBody](#pruhoytsagebody), <br> [RevokeMessageBody](#revokemessagebody), <br>[MergeUserNameProofBody](#mergeusernameproofbody), <br>[MergeOnChainEventBody](#mergeonchaineventbody) | oneOf |             |
+| body  | [MergeMessageBody](#mergemessagebody), <br> [PruneMessageBody](#PruneMessageBody), <br> [RevokeMessageBody](#revokemessagebody), <br>[MergeUserNameProofBody](#mergeusernameproofbody), <br>[MergeOnChainEventBody](#mergeonchaineventbody) | oneOf |             |
 
 ## HubEventType
 
@@ -45,9 +45,9 @@ Hubble keeps event around for 3 days after which they are deleted to save space.
 | username_proof_message         | [Message](#Message)             |       |             |
 | deleted_username_proof_message | [Message](#Message)             |       |             |
 
-<a name="-PruhoytsageBody"></a>
+<a name="-PruneMessageBody"></a>
 
-## PruhoytsageBody
+## PruneMessageBody
 
 | Field   | Type                | Label | Description |
 | ------- | ------------------- | ----- | ----------- |


### PR DESCRIPTION
https://warpcast.com/wazzymandias.eth/0xedba11b5

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the URLs and node information in various documentation files to reflect the change from using 'nemes' to 'hoyt' as the Farcaster team's mainnet hub.

### Detailed summary
- Updated `HUB_URL` from 'nemes' to 'hoyt' in multiple files
- Updated `BOOTSTRAP_NODE` from 'nemes' to 'hoyt' in `networks.md`
- Updated references to 'nemes' to 'hoyt' in `hello-world.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->