### PR TITLE
add: `/reference/warpcast/links.md` page

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -415,6 +415,7 @@ export default defineConfig({
             { text: 'Cast Intents', link: '/reference/warpcast/cast-composer-intents' },
             { text: 'Direct Casts', link: '/reference/warpcast/direct-casts' },
             { text: 'Embeds', link: '/reference/warpcast/embeds' },
+            { text: 'Links', link: '/reference/warpcast/links' },
           ],
         },
         {

--- a/docs/reference/warpcast/links.md
+++ b/docs/reference/warpcast/links.md
@@ -1,0 +1,9 @@
+# Warpcast Links
+
+This page documents several `warpcast.com/~/` pages that developers might find useful both in testing and in their official integrations.
+- `warpcast.com/~/profiles/[fid]` - Profile page for a given profile's FID
+- `warpcast.com/~/conversations/[hash]` - Conversation page for a given cast's hash
+- `warpcast.com/~/developers/embeds?url=[embedUrl]` - Embed testing page for a given embed's URL
+- `warpcast.com/~/developers/frames?url=[frameUrl]` - Frame testing page for a given frame's URL
+`warpcast.com/~/compose?text=[text]` - [Cast intents](/reference/warpcast/cast-intents)
+- `warpcast.com/~/inbox//create/[fid]?text=[message]` - [Direct cast intents](/reference/warpcast/direct-casts#direct-cast-intents)

--- a/docs/reference/warpcast/links.md
+++ b/docs/reference/warpcast/links.md
@@ -5,5 +5,5 @@ This page documents several `warpcast.com/~/` pages that developers might find u
 - `warpcast.com/~/conversations/[hash]` - Conversation page for a given cast's hash
 - `warpcast.com/~/developers/embeds?url=[embedUrl]` - Embed testing page for a given embed's URL
 - `warpcast.com/~/developers/frames?url=[frameUrl]` - Frame testing page for a given frame's URL
-`warpcast.com/~/compose?text=[text]` - [Cast intents](/reference/warpcast/cast-intents)
+- `warpcast.com/~/compose?text=[text]` - [Cast intents](/reference/warpcast/cast-intents)
 - `warpcast.com/~/inbox//create/[fid]?text=[message]` - [Direct cast intents](/reference/warpcast/direct-casts#direct-cast-intents)


### PR DESCRIPTION
Adds `/reference/warpcast/links.md` to document several of the `warpcast.com/~/` routes that developers might find useful.

<img width="1267" alt="Screenshot 2024-07-14 at 2 34 39 PM" src="https://github.com/user-attachments/assets/7553bf14-6300-4421-b220-5bf022dc976f">

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new section "Warpcast Links" to the documentation with detailed links for developers to use in testing and integrations.

### Detailed summary
- Added a new section "Warpcast Links" in `docs/reference/warpcast/links.md`
- Documented several `warpcast.com/~/` pages with descriptions for developers
- Included links for profile pages, conversation pages, embed testing, frame testing, cast intents, and direct cast intents

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->