### PR TITLE
add Warpcast resource url docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -412,7 +412,7 @@ export default defineConfig({
           items: [
             { text: 'APIs', link: '/reference/warpcast/api' },
             { text: 'Signer Requests', link: '/reference/warpcast/signer-requests' },
-            { text: 'Cast Intents', link: '/reference/warpcast/cast-composer-intents' },
+            { text: 'Intent URLs', link: '/reference/warpcast/cast-composer-intents' },
             { text: 'Direct Casts', link: '/reference/warpcast/direct-casts' },
             { text: 'Embeds', link: '/reference/warpcast/embeds' },
           ],

--- a/docs/reference/warpcast/cast-composer-intents.md
+++ b/docs/reference/warpcast/cast-composer-intents.md
@@ -1,37 +1,42 @@
-# Warpcast Cast Intents
+---
+title: Warpcast Intents URLs
+---
+
+# Intents URLs
+
+## Cast Intent URLs
 
 Warpcast intents enable builders to direct authenticated users to a pre-filled cast composer.
 
 #### Compose with cast text
 
-```bash
+```
 https://warpcast.com/~/compose?text=Hello%20world!
 ```
 
 #### Compose with cast text and one embed
 
-```bash
+```
 https://warpcast.com/~/compose?text=Hello%20world!&embeds[]=https://farcaster.xyz
 ```
 
 #### Compose with cast text with mentions and two embeds
 
-```bash
+```
 https://warpcast.com/~/compose?text=Hello%20@farcaster!&embeds[]=https://farcaster.xyz&embeds[]=https://github.com/farcasterxyz/protocol
 ```
 
 #### Compose with cast text on a specific channel
 
-```bash
+```
 https://warpcast.com/~/compose?text=Hello%20world!&channelKey=farcaster
 ```
 
 #### Reply with cast text to a cast with hash
 
-```bash
+```
 https://warpcast.com/~/compose?text=Looks%20good!&parentCastHash=0x09455067393562d3296bcbc2ec1c2d6bba8ac1f1
 ```
-
 
 #### Additional details
 
@@ -39,3 +44,17 @@ https://warpcast.com/~/compose?text=Looks%20good!&parentCastHash=0x0945506739356
 - URLs ending with `.png` `.jpg` or `.gif` will render as an image embed
 - Embedding the URL to a Zora mint page will render the NFT with a mint link below it.
 - You can check how embeds will be rendered in Warpcast at https://warpcast.com/~/developers/embeds
+
+## Resource URLs
+
+#### View profile by FID
+
+```
+https://warpcast.com/~/profiles/:fid
+```
+
+#### View cast by hash
+
+```
+https://warpcast.com/~/conversations/:hash
+```


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the Warpcast documentation with new sections on Intent URLs and Resource URLs.

### Detailed summary
- Updated the navigation link to 'Intent URLs' in the documentation
- Added a new section 'Warpcast Intents URLs' with detailed information on composing cast intents
- Included examples of composing with text, embeds, channel key, and parent cast hash
- Added information on how embeds are rendered and provided sample URLs for resource viewing

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->