### PR TITLE
chore: update hub storage requirements

### DIFF
--- a/docs/hubble/install.md
+++ b/docs/hubble/install.md
@@ -8,7 +8,7 @@ Hubble can be set up in less than 30 minutes. You'll need a machine that has:
 
 - 16 GB of RAM
 - 4 CPU cores or vCPUs
-- 40 GB of free storage
+- 200 GB of free storage
 - A public IP address with ports 2281 - 2283 exposed
 - RPC endpoints for Ethereum and Optimism Mainnet. (use [Alchemy](https://www.alchemy.com/), [Infura](https://www.infura.io/), or [QuickNode](https://www.quicknode.com/))
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the storage requirement in the installation documentation for Hubble from 40 GB to 200 GB.

### Detailed summary
- Increased free storage requirement from 40 GB to 200 GB in `docs/hubble/install.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->