### PR TITLE
fix og image

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -10,7 +10,7 @@ export default defineConfig({
     ['meta', { property: 'og:type', content: 'website' }],
     [
       'meta',
-      { property: 'og:image', content: 'https://farcaster.xyz/og-image.png' },
+      { property: 'og:image', content: '/og-image.png' },
     ],
     ['meta', { property: 'og:url', content: 'https://farcaster.xyz' }],
     [


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `og:image` content URL in the VitePress configuration file.

### Detailed summary
- Updated `og:image` content URL to '/og-image.png' in `docs/.vitepress/config.mts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->