### PR TITLE
tweak home language

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ hero:
       text: Build a frame
       link: /developers/frames/
     - theme: alt
-      text: Explore social sign in
+      text: Explore Sign In with Farcaster
       link: /developers/siwf/
     - theme: alt
       text: Learn about the protocol
@@ -24,12 +24,12 @@ Learn how to build frames, which are mini-apps that run inside a Farcaster feed.
 - [Build your first frame](/developers/frames/getting-started) - Make mini-apps that run inside Farcaster.
 - [Specification](/developers/frames/spec) - A formal specification for the Frame standard.
 
-### Explore social sign-in
+### Explore Sign In with Farcaster
 
 Allow users to Sign In with Farcaster and leverage social data in your app.
 
-- [Introduction](/developers/siwf/) - Learn about Sign In with Farcaster (SIWF).
-- [Add SWIF with AuthKit](/auth-kit/installation) - a React toolkit to add SIWF to your app.
+- [Introduction](/developers/siwf/) - Learn about Sign In with Farcaster.
+- [Add SIWF using AuthKit](/auth-kit/installation) - a React toolkit to add SIWF to your app.
 - [Examples](/auth-kit/examples) - see Sign In with Farcaster in action.
 
 ### Analyze Farcaster data


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the text and links related to social sign-in functionality to now focus on Sign In with Farcaster. 

### Detailed summary
- Updated text from "social sign in" to "Sign In with Farcaster"
- Changed link destinations and text related to Sign In with Farcaster
- Renamed references to "SIWF" to "Sign In with Farcaster"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->