### PR TITLE
update: Added packages that depend on the hub

### DIFF
--- a/docs/developers/resources.md
+++ b/docs/developers/resources.md
@@ -23,6 +23,9 @@ Resources are often from third parties and are not reviewed. Use them at your ow
 ### Hubs
 
 - [@farcaster/hub-nodejs](https://www.npmjs.com/package/@farcaster/hub-nodejs) - lightweight, fast Typescript interface for Farcaster Hubs.
+- [@farcaster/shuttle](https://www.npmjs.com/package/@farcaster/shuttle) - package that streams Hubble events to Postgres.
+- [@farcaster/hub-web](https://www.npmjs.com/package/@farcaster/hub-web) - browser client library for Hubble.
+- [@farcaster/core](https://www.npmjs.com/package/@farcaster/core) - shared code between all Packages.
 
 ### Onchain
 


### PR DESCRIPTION
# Should add packages that depend on the Hub? Please consider this. 
ref.https://github.com/farcasterxyz/hub-monorepo?tab=readme-ov-file#packages cc.https://docs.farcaster.xyz/developers/resources#hubs

**Review this PR update. 👇**
from:
![image](https://github.com/user-attachments/assets/a9e85d64-da70-4e9e-b8b6-cc3bbeac1b2b)

to:
![image](https://github.com/user-attachments/assets/9b3626c8-b16a-4c71-9ade-0a3928fa1cae)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the resources.md file with new Farcaster packages related to Hubble events and core functionality.

### Detailed summary
- Updated package references:
  - Added `@farcaster/shuttle`
  - Added `@farcaster/hub-web`
  - Added `@farcaster/core`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->