### PR TITLE
Add Zero to Hero Guides as Ressources

### DIFF
--- a/docs/developers/frames/resources.md
+++ b/docs/developers/frames/resources.md
@@ -10,6 +10,7 @@ An opinionated collection of popular resources for building Frames.
 
 - [/fc-devs](https://warpcast.com/~/channel/fc-devs) - Farcaster developer channel
 - [Frames Specification](./spec) - official Frames specification
+- [dTech Zero to Hero Getting Started Guides](https://dtech.vision/farcaster/frames/)
 - [Frames.js Guide](https://framesjs.org/guides/create-frame) - guides from Frames.js
 - [Frog Guides](https://framesjs.org/guides/create-frame) - guides from Frog
 - [Frame Interface Guidelines (FIG)](https://github.com/paradigmxyz/Fig) - guidance and best practices for building frames

--- a/docs/developers/resources.md
+++ b/docs/developers/resources.md
@@ -34,6 +34,10 @@ Resources are often from third parties and are not reviewed. Use them at your ow
 - [Dune: Farcaster](https://dune.com/pixelhack/farcaster) - @pixelhack's dashboard for network stats
 - [Dune: Farcaster User Onchain Activities](https://dune.com/yesyes/farcaster-users-onchain-activities) - dashboard of farcaster user's onchain activity
 
+## Learning
+
+- [dTech Farcaster Tutorials](https://dtech.vision/farcaster)
+
 ## Open Source Examples
 
 - [quikcast](https://github.com/farcasterxyz/quikcast) - an end-to-end connected app implementation for Farcaster
@@ -42,3 +46,4 @@ Resources are often from third parties and are not reviewed. Use them at your ow
 ## Services
 
 - [Neynar](https://neynar.com/) - infrastructure and services for building farcaster apps.
+- [dTech](https://dtech.vision) - Farcaster Development and Consulting Agency


### PR DESCRIPTION
Add the dTech ressources focused on getting developers started without knowing anything about Farcaster as options to the documentation.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates developer resources in the documentation. It adds dTech Zero to Hero Getting Started Guides and dTech Farcaster Tutorials, and includes dTech as a Farcaster Development and Consulting Agency.

### Detailed summary
- Added dTech Zero to Hero Getting Started Guides link
- Added dTech Farcaster Tutorials link
- Added dTech as Farcaster Development and Consulting Agency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->