### PR TITLE
fix 404 for AuthKit Introduction

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -309,7 +309,7 @@ export default defineConfig({
       '/auth-kit/': [
         {
           text: 'Overview',
-          items: [{ text: 'Introduction', link: '/auth-kit/introduction' },{
+          items: [{ text: 'Introduction', link: '/auth-kit/' },{
             text: 'Examples',
             link: '/auth-kit/examples',
           },],


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the link for the "Introduction" page in the Vitepress configuration file.

### Detailed summary
- Updated the link for the "Introduction" page in the Vitepress configuration file from '/auth-kit/introduction' to '/auth-kit/'.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->