### PR TITLE
Fixed grammatical and text errors in Farcaster documentation

### DIFF
--- a/docs/developers/frames/advanced.md
+++ b/docs/developers/frames/advanced.md
@@ -9,7 +9,7 @@ Advanced topics for building sophisticated Farcaster Frames.
 #### Making the initial Frame image dynamic
 
 When a Frame is shared in a cast the metadata for it will generally be scraped
-and cached so that it can be rendered into user's feeds without additional
+and cached so that it can be rendered into users feeds without additional
 loading. This means whatever URL is set on the initial frame will always be
 rendered.
 
@@ -19,7 +19,7 @@ In order to make the initial image dynamic you'll need to:
 - set an appropriate cache header
 
 An example, imagine you want to build a frame where the initial frame shows the
-current price of ETH. For the initial frame you'd set an a static image url
+current price of ETH. For the initial frame you'd set a static image url
 like `https://example.xyz/eth-price.png`. When a GET request is made to this endpoint:
 
 - the server fetches the latest ETH price from a cache
@@ -41,11 +41,11 @@ image for cases when you're unable to generate the image, you should set
 As an example, let's say you generate a dynamic image at `/img/eth-price` that
 shows a 24hr chart for the price of ETH. Normally you want this image to be
 cached for 5 minutes. However, if the ETH price data is unavailable and you
-render an fallback image you don't want the request cached so that you can try
+render a fallback image you don't want the request cached so that you can try
 again in subsequent requests.
 
 #### Data persistence
 
-[Vercel KV](https://vercel.com/docs/storage/vercel-kv) and [Cloudflare Wokers
+[Vercel KV](https://vercel.com/docs/storage/vercel-kv) and [Cloudflare Workers
 KV](https://developers.cloudflare.com/kv/) are convenient options for adding a
 simple persistence layer to your Frame server.

--- a/docs/developers/frames/best-practices.md
+++ b/docs/developers/frames/best-practices.md
@@ -32,7 +32,7 @@ the [performance best practices](#performance).
 
 #### Use reusable styles and components
 
-Building set of reusable styles and components can help you move fast and build
+Building a set of reusable styles and components can help you move fast and build
 consistent interfaces.
 
 [FrogUI](https://frog.fm/ui) is an extension of the Frog Framework that provides a theme-able
@@ -71,7 +71,7 @@ locally.
 
 ::: warning Advanced
 Maintaining a replicated database is a non-trivial amount of work. Consider
-fetching data from a provider like Neynar, Pinata, or Airstack unless your
+fetching data from a provider like Neynar, Pinata, or Airstack unless you're
 willing to pay this cost.
 :::
 

--- a/docs/hubble/hubble.md
+++ b/docs/hubble/hubble.md
@@ -16,7 +16,7 @@ network.
 Hubble instances can also be hosted for you by other service providers.
 
 - [Hubs x Neynar](https://hubs.neynar.com/)
-- [Hubs X Pinata](https://pinata.cloud/pinata-hub)
+- [Hubs x Pinata](https://pinata.cloud/pinata-hub)
 
 ## Public Instances
 

--- a/docs/hubble/networks.md
+++ b/docs/hubble/networks.md
@@ -4,7 +4,7 @@ A Farcaster account must choose which network it posts its messages to. Any acco
 
 There are two main networks:
 
-- **Testnet**- the latest beta release intended for developers
+- **Testnet** - the latest beta release intended for developers
 - **Mainnet** - the stable version that everyone uses
 
 When [installing your hub](./install.md), you'll need to choose a network to connect to.


### PR DESCRIPTION
Fix #288 


This pull request addresses several textual errors found in the Farcaster documentation. The changes include fixing grammatical mistakes and improving the overall readability of the text. No structural changes were made, and the content remains consistent with the original intent of the documentation.

These corrections help ensure that the documentation is clearer and more polished for users and developers.


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to make minor text corrections and improve consistency in documentation related to Hubble, networks, and best practices for developers.

### Detailed summary
- Corrected capitalization and spacing in URLs and text
- Improved wording for clarity and consistency
- Updated instructions for developers on best practices in building interfaces

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->