### PR TITLE
Warpcast video rendering reference

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -450,6 +450,7 @@ export default defineConfig({
             { text: 'Intent URLs', link: '/reference/warpcast/cast-composer-intents' },
             { text: 'Direct Casts', link: '/reference/warpcast/direct-casts' },
             { text: 'Embeds', link: '/reference/warpcast/embeds' },
+            { text: 'Videos', link: '/reference/warpcast/videos' },
           ],
         },
         {

--- a/docs/reference/warpcast/videos.md
+++ b/docs/reference/warpcast/videos.md
@@ -1,0 +1,21 @@
+# How to have your video displayed on Warpcast
+
+1. Ensure you serve your video as a streamable `.m3u8` file. This ensures clients only download what they need when viewing, and nothing more, providing a high performance experience.
+
+2. Make sure that `.m3u8` manifest exposes the resolution(s) for your video. Warpcast uses this to determine the correct aspect ratio when rendering. A manifest file with resolution data looks something like:
+
+```
+#EXTM3U
+#EXT-X-VERSION:3
+
+#EXT-X-STREAM-INF:BANDWIDTH=2444200,CODECS="avc1.64001f,mp4a.40.2",RESOLUTION=474x842
+480p/video.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=4747600,CODECS="avc1.640020,mp4a.40.2",RESOLUTION=720x1280
+720p/video.m3u8
+```
+
+3. Ensure that at cast publish time the `.m3u8` file is available. Warpcast checks once and if there is no valid data, the cast will show no video.
+
+4. Have the same URL when changed from ending in `/my-video.m3u8` to `/thumbnail.jpg` with a preview/thumbnail image to render before the user has interacted with the video.
+
+5. Reach out to the Warpcast team and ask for us to enable videos for your domain. Tell us the format of your video URLs and we’ll configure our scrapers to display them correctly in the feed. Please make sure to complete all these steps above before reaching out for allowlisting. [Ping @gt on Warpcast](https://warpcast.com/~/inbox/create/302?text=Completed%20video%20setup).


### PR DESCRIPTION
This used to live on Notion - moving it to docs instead.


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add support for displaying videos on Warpcast by introducing a guide for setting up video streaming and resolution manifests.

### Detailed summary
- Added a new `Videos` section to the Warpcast reference menu
- Created a guide in `videos.md` explaining how to serve videos as `.m3u8` files
- Provided steps for ensuring video availability and correct rendering on Warpcast
- Included instructions for requesting video support for a domain

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->