### PR TITLE
fix: Correct package name in documentation

### DIFF
--- a/docs/developers/guides/accounts/create-account-key.md
+++ b/docs/developers/guides/accounts/create-account-key.md
@@ -4,7 +4,7 @@ An account can authorize account keys, which can create messages on its behalf.
 
 The owner of the account can revoke an account key at any time. To add an account key, you'll need to follow six steps:
 
-1. Set up [Viem](https://viem.sh/) clients and [`@farcaster/hub-web`](https://www.npmjs.com/package/@farcaster/hub-web) account key.
+1. Set up [Viem](https://viem.sh/) clients and [`@farcaster/hub-nodejs`](https://www.npmjs.com/package/@farcaster/hub-nodejs) account key.
 2. Register an [app fid](/reference/contracts/faq#what-is-an-app-fid-how-do-i-get-one) if your app does not already have one.
 3. Create a new account key for the user.
 4. Use your app account to create a [Signed Key Request](/reference/contracts/reference/signed-key-request-validator).
@@ -18,7 +18,7 @@ The owner of the account can revoke an account key at any time. To add an accoun
 
 ### 1. Set up clients and account key
 
-First, set up Viem clients and `@farcaster/hub-web` account key. In this example, we'll use Viem local accounts and account key, but
+First, set up Viem clients and `@farcaster/hub-nodejs` account key. In this example, we'll use Viem local accounts and account key, but
 you can also use `ViemWalletEip712Signer` to connect to a user's wallet rather than a local account.
 
 ```ts

--- a/docs/developers/guides/accounts/create-account.md
+++ b/docs/developers/guides/accounts/create-account.md
@@ -9,7 +9,7 @@
 
 You can register a new user using the Bundler contract. To do so, you'll need to:
 
-1. Set up [Viem](https://viem.sh/) clients and [`@farcaster/hub-web`](https://www.npmjs.com/package/@farcaster/hub-web) account keys.
+1. Set up [Viem](https://viem.sh/) clients and [`@farcaster/hub-nodejs`](https://www.npmjs.com/package/@farcaster/hub-nodejs) account keys.
 2. Register an [app fid](/reference/contracts/faq#what-is-an-app-fid-how-do-i-get-one) if your app does not already have one.
 3. Collect a [`Register`](/reference/contracts/reference/id-gateway#register-signature) signature from the user.
 4. Create a new account key pair for the user.
@@ -19,7 +19,7 @@ You can register a new user using the Bundler contract. To do so, you'll need to
 
 ### 1. Set up clients and account keys
 
-First, set up Viem clients and `@farcaster/hub-web` account keys. In this example, we'll use Viem local accounts and account keys, but
+First, set up Viem clients and `@farcaster/hub-nodejs` account keys. In this example, we'll use Viem local accounts and account keys, but
 you can also use `ViemWalletEip712Signer` to connect to a user's wallet rather than a local account.
 
 ```ts


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates references from `@farcaster/hub-web` to `@farcaster/hub-nodejs` in two documentation files.

### Detailed summary
- Updated references from `@farcaster/hub-web` to `@farcaster/hub-nodejs` in `create-account.md`
- Updated references from `@farcaster/hub-web` to `@farcaster/hub-nodejs` in `create-account-key.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->