### PR TITLE
fixed documentation error

### DIFF
--- a/docs/hubble/troubleshooting.md
+++ b/docs/hubble/troubleshooting.md
@@ -52,9 +52,7 @@ BOOTSTRAP_NODE=/dns/hoyt.farcaster.xyz/tcp/2282
 
 Use the [grafana dashboard](/hubble/monitoring) to monitor your hub. The Status tab will show the message sync
 percent of your hub compared to its peers. If this is less than 100%, try restarting the hub and waiting a while. If
-this
-persists, reach out on the [Developer Chat](https://t.me/farcasterdevchat) or file an issue on
-the [hub repo](https://github.com/farcasterxyz/hub-monorepo/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=bug%20%28hubble%29%3A).
+this persists, file an issue on the [hub repo](https://github.com/farcasterxyz/hub-monorepo/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=bug%20%28hubble%29%3A).
 
 ## Managing your Peer ID
 


### PR DESCRIPTION
Removed link to Developer Chat in Telegram because this user does not exist
<img width="285" alt="User does not exist" src="https://github.com/user-attachments/assets/6b7a024e-c0d0-4f54-bcc7-7868ae5609af">
