### PR TITLE
SCAM link on the farcaster.xyz 

### DIFF
--- a/docs/learn/contributing/overview.md
+++ b/docs/learn/contributing/overview.md
@@ -30,6 +30,3 @@ great way to get involved.
 - [Recordings](https://www.youtube.com/watch?v=lmGXWP5m1_Y&list=PL0eq1PLf6eUeZnPtyKMS6uN9I5iRIlnvq) - watch recordings
   of previous calls.
 
-## Community
-
-- [Developer Telegram](https://t.me/farcasterdevchat) - Public chat for developer support.


### PR DESCRIPTION
Fixes #298 

This Pull Request removes a phishing link from the documentation section of the official website (docs.farcaster.xyz) that redirected users to a fraudulent site (farcaster.fi) via a Telegram channel. This change is intended to prevent potential fraud and theft of user funds, as well as to protect Farcaster's reputation. I kindly request a prompt review and merge to minimize the risk to the community.

My Warpcast: https://warpcast.com/pavel01

<img width="1272" alt="Screenshot 1" src="https://github.com/user-attachments/assets/75e727e4-7ed4-425a-a2de-8697b7cc0a92">
<img width="1272" alt="Screenshot 2" src="https://github.com/user-attachments/assets/9e723358-c668-48a0-8deb-775cebdc6c42">
<img width="1274" alt="Screenshot 3" src="https://github.com/user-attachments/assets/a05ecfd4-9926-485e-b64f-85776eb68608">
<img width="904" alt="Screenshot 4" src="https://github.com/user-attachments/assets/16bb1cc1-5e09-4e81-a0d1-2b280077bb87">
<img width="904" alt="Screenshot 5" src="https://github.com/user-attachments/assets/3da06817-0dac-45e2-9f4c-64425d617d89">
<img width="902" alt="Screenshot 6" src="https://github.com/user-attachments/assets/fea3d8ab-ce88-44ee-9800-85251ca1f8a7">
<img width="1269" alt="Screenshot 7" src="https://github.com/user-attachments/assets/0409a952-b4cc-4337-bbec-1c4c12a25c3a">
<img width="1280" alt="Screenshot 8" src="https://github.com/user-attachments/assets/426fb32a-369e-4a67-aafe-9d0046ad3738">

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `overview.md` file in the `contributing` section of the documentation by removing a link to the Developer Telegram group.

### Detailed summary
- Removed the link to the Developer Telegram group in the Community section.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->