### PR TITLE
Fix 404 page

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -250,7 +250,7 @@ export default defineConfig({
               items: [
                 {
                   text: 'Create an account',
-                  link: '/developers/guides/writing/accounts',
+                  link: '/developers/guides/accounts/create-account',
                 },
                 {
                   text: 'Create messages',


### PR DESCRIPTION
"Create an account" section in "Writing data" redirect to a 404 page: https://docs.farcaster.xyz/developers/guides/writing/accounts