### PR TITLE
Fix signer key requests example implementations

### DIFF
--- a/docs/reference/warpcast/signer-requests.md
+++ b/docs/reference/warpcast/signer-requests.md
@@ -155,7 +155,7 @@ const poll = async (token: string) => {
           token,
         },
       })
-      .then((response) => response.data.result);
+      .then((response) => response.data.result.signedKeyRequest);
 
     if (signedKeyRequest.state === 'completed') {
       console.log('Signed Key Request completed:', signedKeyRequest);
@@ -260,7 +260,7 @@ const SIGNED_KEY_REQUEST_TYPE = [
             token,
           },
         })
-        .then((response) => response.data.result);
+        .then((response) => response.data.result.signedKeyRequest);
 
       if (signedKeyRequest.state === 'completed') {
         console.log('Signed Key Request completed:', signedKeyRequest);

--- a/docs/reference/warpcast/signers.md
+++ b/docs/reference/warpcast/signers.md
@@ -156,7 +156,7 @@ const poll = async (token: string) => {
           token,
         },
       })
-      .then((response) => response.data.result);
+      .then((response) => response.data.result.signedKeyRequest);
 
     if (signedKeyRequest.state === 'completed') {
       console.log('Signed Key Request completed:', signedKeyRequest);
@@ -261,7 +261,7 @@ const SIGNED_KEY_REQUEST_TYPE = [
             token,
           },
         })
-        .then((response) => response.data.result);
+        .then((response) => response.data.result.signedKeyRequest);
 
       if (signedKeyRequest.state === 'completed') {
         console.log('Signed Key Request completed:', signedKeyRequest);


### PR DESCRIPTION
Updates `poll` function response to make sure the `signedKeyRequest` key is accessed, allowing the `state` check to proceed and enter the `completed` block.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the code to access the `signedKeyRequest` property from the response data result in `warpcast/signers.md` and `warpcast/signer-requests.md`.

### Detailed summary
- Updated code to access `signedKeyRequest` property in response data result for signers and signer requests.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->