### PR TITLE
Removed the hyphen in onchain and offchain to maintain a consistent style 

### DIFF
--- a/docs/developers/guides/basics/hello-world.md
+++ b/docs/developers/guides/basics/hello-world.md
@@ -167,7 +167,7 @@ const accountPrivateKey = await getOrRegisterAccountKey(fid);
 
 ## 4. Register an fname
 
-Now that the on-chain actions are complete, let's register an fname using the farcaster off-chain fname registry.
+Now that the onchain actions are complete, let's register an fname using the farcaster offchain fname registry.
 Registering an fname requires a signature from the custody address of the fid.
 
 ```typescript

--- a/docs/reference/replicator/schema.md
+++ b/docs/reference/replicator/schema.md
@@ -4,7 +4,7 @@ The following tables are created in Postgres DB where data from the Hubs are sto
 
 ## chain_events
 
-All on-chain events received from the hub event stream are stored in this table. These events represent any on-chain
+All onchain events received from the hub event stream are stored in this table. These events represent any onchain
 action including registrations, transfers, signer additions/removals, storage rents, etc. Events are never deleted (i.e.
 this table is append-only).
 
@@ -221,7 +221,7 @@ Stores how many units of storage each FID has purchased, and when it expires.
 | updated_at     | `timestamp with time zone` | When the row was last updated.                                                                               |
 | rented_at      | `timestamp with time zone` | Message timestamp in UTC.                                                                                    |
 | expires_at     | `timestamp with time zone` | When this storage allocation will expire.                                                                    |
-| chain_event_id | `uuid`                     | ID of the row in the `chain_events` table representing the on-chain event where storage was allocated.       |
+| chain_event_id | `uuid`                     | ID of the row in the `chain_events` table representing the onchain event where storage was allocated.       |
 | fid            | `bigint`                   | FID that owns the storage.                                                                                   |
 | units          | `smallint`                 | Number of storage units allocated.                                                                           |
 | payer          | `bytea`                    | Wallet address that paid for the storage.                                                                    |


### PR DESCRIPTION
"The community has generally settled on onchain and offchain as individual words, rather than hyphenated." - @sds
https://github.com/farcasterxyz/docs/pull/296#discussion_r1744299916

Removed the hyphen in onchain and offchain to maintain a consistent style 



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation to use consistent terminology by replacing "on-chain" with "onchain" in specific sections.

### Detailed summary
- Replaced "on-chain" with "onchain" in specific sections for consistency.
- Updated terminology in `hello-world.md` and `schema.md` files.
- Ensured uniformity in describing actions related to the blockchain.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->