### PR TITLE
Update channel APIs docs to include moderatorFids

### DIFF
--- a/docs/learn/contributing/overview.md
+++ b/docs/learn/contributing/overview.md
@@ -29,4 +29,3 @@ great way to get involved.
   Calendar invite to join upcoming calls.
 - [Recordings](https://www.youtube.com/watch?v=lmGXWP5m1_Y&list=PL0eq1PLf6eUeZnPtyKMS6uN9I5iRIlnvq) - watch recordings
   of previous calls.
-

--- a/docs/reference/replicator/schema.md
+++ b/docs/reference/replicator/schema.md
@@ -221,7 +221,7 @@ Stores how many units of storage each FID has purchased, and when it expires.
 | updated_at     | `timestamp with time zone` | When the row was last updated.                                                                               |
 | rented_at      | `timestamp with time zone` | Message timestamp in UTC.                                                                                    |
 | expires_at     | `timestamp with time zone` | When this storage allocation will expire.                                                                    |
-| chain_event_id | `uuid`                     | ID of the row in the `chain_events` table representing the onchain event where storage was allocated.       |
+| chain_event_id | `uuid`                     | ID of the row in the `chain_events` table representing the onchain event where storage was allocated.        |
 | fid            | `bigint`                   | FID that owns the storage.                                                                                   |
 | units          | `smallint`                 | Number of storage units allocated.                                                                           |
 | payer          | `bytea`                    | Wallet address that paid for the storage.                                                                    |

--- a/docs/reference/warpcast/api.md
+++ b/docs/reference/warpcast/api.md
@@ -32,7 +32,18 @@ List all Warpcast channels. There are no parameters and no pagination.
 curl https://api.warpcast.com/v2/all-channels | jq
 ```
 
-Returns: an array of channel objects:
+Returns: a `channels` array wtih properties:
+
+- `id` - unique channel id that cannot be changed (called 'Name' when creating a channel)
+- `url` - FIP-2 `parentUrl` used for main casts in the channel
+- `name` - friendly name displayed to users (called 'Display name' when editing a channel)
+- `description` - description of the channel, if present
+- `imageUrl` - URL to the channel avatar
+- `leadFid` - fid of the user who created the channel, if present
+- `moderatorFid` - (**deprecated**) fid of the user who moderates the main channel feed, if present
+- `moderatorFids` - fids of the moderators (under new channel membership scheme)
+- `createdAt` - UNIX time when channel was created, in seconds
+- `followerCount` - number of users following the channel
 
 ```json
 {
@@ -46,6 +57,10 @@ Returns: an array of channel objects:
         "imageUrl": "https://ipfs.decentralized-content.com/ipfs/bafkreieraqfkny7bttxd7h7kmnz6zy76vutst3qbjgjxsjnvrw7z3i2n7i",
         "leadFid": 1593,
         "moderatorFid": 5448,
+        "moderatorFids": [
+          5448,
+          3
+        ],
         "createdAt": 1691015606,
         "followerCount": 3622
       },
@@ -54,18 +69,6 @@ Returns: an array of channel objects:
   }
 }
 ```
-
-Channel object properties:
-
-- `id` - unique channel id that cannot be changed (called 'Name' when creating a channel)
-- `url` - FIP-2 `parentUrl` used for main casts in the channel
-- `name` - friendly name displayed to users (called 'Display name' when editing a channel)
-- `description` - description of the channel, if present
-- `imageUrl` - URL to the channel avatar
-- `leadFid` - fid of the user who created the channel, if present
-- `moderatorFid` - fid of the user who moderates the main channel feed, if present
-- `createdAt` - UNIX time when channel was created, in seconds
-- `followerCount` - number of users following the channel
 
 ### Get Channel
 
@@ -92,6 +95,7 @@ Returns: a single channel object, as documented in the "Get All Channels" endpoi
       "imageUrl": "https://ipfs.decentralized-content.com/ipfs/bafkreieraqfkny7bttxd7h7kmnz6zy76vutst3qbjgjxsjnvrw7z3i2n7i",
       "leadFid": 1593,
       "moderatorFid": 5448,
+      "moderatorFids": [5448, 3],
       "createdAt": 1691015606,
       "followerCount": 3622
     }
@@ -111,12 +115,10 @@ Parameters:
 
 - `channelId` - the id of the channel
 
-Returns: two arrays:
+Returns: a `users` array with properties:
 
-- `users` - objects with properties:
-  - `fid` - the fid of the user
-  - `followedAt` - UNIX time when channel was followed, in seconds
-- (**DEPRECATED, will be removed soon**) `fids` - the fids of the users
+- `fid` - the fid of the user
+- `followedAt` - UNIX time when channel was followed, in seconds
 
 ```json
 {
@@ -132,11 +134,6 @@ Returns: two arrays:
       },
       ...
     ],
-    "fids": [
-      466624,
-      469283,
-      ...
-    ]
   },
   "next": { "cursor": "..." }
 }
@@ -154,7 +151,10 @@ Parameters:
 
 - `fid` - the fid of the user
 
-Returns: an array of objects:
+Returns: a `channels` array with properties:
+
+- All properties documented in the "Get All Channels" endpoint above
+- `followedAt` - UNIX time when channel was followed, in seconds
 
 ```json
 {
@@ -168,6 +168,10 @@ Returns: an array of objects:
         "imageUrl": "https://i.imgur.com/YnnrPaH.png",
         "leadFid": 2,
         "moderatorFid": 5448,
+        "moderatorFids": [
+          5448,
+          3
+        ],
         "createdAt": 1712162074,
         "followerCount": 17034,
         "followedAt": 1712162620
@@ -178,11 +182,6 @@ Returns: an array of objects:
   "next": { "cursor": "..." }
 }
 ```
-
-Object properties:
-
-- All properties documented in the "Get All Channels" endpoint above
-- `followedAt` - UNIX time when channel was followed, in seconds
 
 ### Get User Following Channel Status
 
@@ -199,6 +198,9 @@ Parameters:
 
 Returns: 2 properties:
 
+- `following` - indicates whether the channel is followed
+- `followedAt` - UNIX time when channel was followed, in seconds (optional, only present when channel is followed)
+
 ```json
 {
   "result": {
@@ -207,11 +209,6 @@ Returns: 2 properties:
   }
 }
 ```
-
-Properties:
-
-- `following` - indicates whether the channel is followed
-- `followedAt` - UNIX time when channel was followed, in seconds (optional, only present when channel is followed)
 
 ## Get All Power Badge Users
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR primarily updates documentation related to the `chain_event_id` field in the `replicator` schema and enhances the API documentation for Warpcast channels, including changes to the channel object properties and the addition of `moderatorFids`.

### Detailed summary
- Updated `chain_event_id` field description in `schema.md`.
- Changed return format for channel objects in `api.md` to specify `channels` array.
- Added `moderatorFids` property to channel object.
- Revised descriptions for channel properties for clarity.
- Updated user following channel status to include `following` and `followedAt` properties.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->