### PR TITLE
Add new memberCount and pinnedCastHash properties returned for channels

### DIFF
--- a/docs/reference/warpcast/api.md
+++ b/docs/reference/warpcast/api.md
@@ -44,6 +44,8 @@ Returns: a `channels` array wtih properties:
 - `moderatorFids` - fids of the moderators (under new channel membership scheme)
 - `createdAt` - UNIX time when channel was created, in seconds
 - `followerCount` - number of users following the channel
+- `memberCount` - number of members of the channel, including the owner and moderators
+- `pinnedCastHash` - hash of the cast pinned in the channel, if present
 
 ```json
 {
@@ -62,7 +64,9 @@ Returns: a `channels` array wtih properties:
           3
         ],
         "createdAt": 1691015606,
-        "followerCount": 3622
+        "followerCount": 3622,
+        "membercount": 123,
+        "pinnedcasthash": "0x3349beda5fb6232ab50d7b0e4d49da3d56814771"
       },
       ...
     ]
@@ -97,7 +101,9 @@ Returns: a single channel object, as documented in the "Get All Channels" endpoi
       "moderatorFid": 5448,
       "moderatorFids": [5448, 3],
       "createdAt": 1691015606,
-      "followerCount": 3622
+      "followerCount": 3622,
+      "membercount": 123,
+      "pinnedcasthash": "0x3349beda5fb6232ab50d7b0e4d49da3d56814771"
     }
   }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the documentation for the `warpcast` API to include new properties related to channels, enhancing clarity on channel details.

### Detailed summary
- Added `memberCount`: number of members in the channel, including the owner and moderators.
- Added `pinnedCastHash`: hash of the pinned cast in the channel.
- Updated JSON response examples to include `memberCount` and `pinnedCastHash`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->