### PR TITLE
Fix DC docs typo

### DIFF
--- a/docs/reference/warpcast/direct-casts.md
+++ b/docs/reference/warpcast/direct-casts.md
@@ -12,7 +12,7 @@ This page documents public APIs provided by Warpcast for direct casts. Direct ca
 Intents enable developers to direct authenticated users to a pre-filled direct cast composer via a URL.
 
 ```bash
-https://warpcast.com/~/inbox//create/[fid]?text=[message]
+https://warpcast.com/~/inbox/create/[fid]?text=[message]
 
 https://warpcast.com/~/inbox/create/1?text=gm
 ```


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on correcting a URL format in the `docs/reference/warpcast/direct-casts.md` file by removing an unnecessary double slash.

### Detailed summary
- Changed the URL from `https://warpcast.com/~/inbox//create/[fid]?text=[message]` to `https://warpcast.com/~/inbox/create/[fid]?text=[message]`
- The example URL `https://warpcast.com/~/inbox/create/1?text=gm` remains unchanged.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->