### PR TITLE
Add the new optional fid query param to the account verifications spec

### DIFF
--- a/docs/reference/warpcast/api.md
+++ b/docs/reference/warpcast/api.md
@@ -798,6 +798,10 @@ curl 'https://api.warpcast.com/v1/blocked-users'
 
 List of account verifications attested by Warpcast. Ordered by the time when the verification occurred, descending. Paginated. Not authenticated.
 
+Query parameters:
+
+- `fid` (**optional**) - limit the response to specific user
+
 Returns: a `verifications` array:
 
 - `fid` - account Farcaster id


### PR DESCRIPTION
Relates farcasterxyz/docs#314


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation for the `Warpcast` API to include details about account verifications and introduces a new optional query parameter.

### Detailed summary
- Added a section on account verifications attested by `Warpcast`.
- Specified that verifications are ordered by time, descending, and are paginated.
- Introduced an optional query parameter: 
  - `fid` - limits the response to a specific user.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->