### PR TITLE
fix: minor fixes in Warpcast Authentication doc

### DIFF
--- a/docs/reference/warpcast/api.md
+++ b/docs/reference/warpcast/api.md
@@ -32,12 +32,12 @@ import { NobleEd25519Signer } from "@farcaster/hub-nodejs";
 const fid = 6841; //replace
 const privateKey = 'secret'; // replace
 const publicKey = 'pubkey'; // replace
-const signer = new NobleEd25519Signer(privateKey);
+const signer = new NobleEd25519Signer(new Uint8Array(Buffer.from(privateKey)));
 
 const header = {
-	fid,
-	type: 'app_key',
-	key: publicKey
+  fid,
+  type: 'app_key',
+  key: publicKey
 };
 const encodedHeader = Buffer.from(JSON.stringify(header)).toString('base64url');
 
@@ -45,9 +45,13 @@ const payload = { exp: Math.floor(Date.now() / 1000) + 300 }; // 5 minutes
 const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
 
 const signatureResult = await signer.signMessageHash(Buffer.from(`${encodedHeader}.${encodedPayload}`, 'utf-8'));
+if (signatureResult.isErr()) {
+  throw new Error("Failed to sign message");
+}
+
 const encodedSignature = Buffer.from(signatureResult.value).toString("base64url");
 
-const authToken = encodedHeader + "." + encodedPayload "." + encodedSignature;
+const authToken = encodedHeader + "." + encodedPayload + "." + encodedSignature;
 
 await got.post(
   "https://api.warpcast.com/fc/channel-follows",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the signing process in the `warpcast` API documentation. It modifies how the `privateKey` is converted to a `Uint8Array` for the `NobleEd25519Signer` and adds error handling for the signing process. Additionally, it corrects a syntax error in the `authToken` concatenation.

### Detailed summary
- Changed the initialization of `signer` to convert `privateKey` to a `Uint8Array`.
- Added error handling for the signing process with a check on `signatureResult`.
- Fixed a syntax error in the `authToken` concatenation by adding a missing `+`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->