### PR TITLE
Rish/neyn 3305 add neynar api reference to farcaster documentation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -305,6 +305,15 @@ export default defineConfig({
             },
           ],
         },
+        {
+          text: 'Third party services',
+          items: [
+            {
+              text: 'Neynar',
+              link: '/reference/third-party/neynar/index',
+            }
+          ]
+        }
       ],
       '/auth-kit/': [
         {
@@ -628,6 +637,15 @@ export default defineConfig({
             // },
           ],
         },
+        {
+          text: 'Third party services',
+          items: [
+            {
+              text: 'Neynar',
+              link: '/reference/third-party/neynar/index',
+            },
+          ],
+        }
       ],
     },
     socialLinks: [

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -8,3 +8,4 @@ The reference sections documents API's, standards and protocols used commonly us
 - [Replicator](/reference/replicator/schema) - An overview and schema for the replicator.
 - [Contracts](/reference/contracts/index) - A design overview and ABI reference for Farcaster contracts.
 - [FName Registry](/reference/fname/api) - An overview and API reference for the Farcaster Name Server.
+- [Neynar](/reference/third-party/neynar/index) - An overview of Neynar APIs that can help developers get started with Farcaster

--- a/docs/reference/third-party/neynar/index.md
+++ b/docs/reference/third-party/neynar/index.md
@@ -1,0 +1,12 @@
+# Neynar
+
+[Neynar](https://neynar.com) is an independent 3rd party provider that offers the following services for Farcaster data:
+
+- [Hosted hubs](https://docs.neynar.com/docs/create-a-stream-of-casts)
+- [REST APIs](https://docs.neynar.com/reference/quickstart)
+- [Signer management](https://docs.neynar.com/docs/which-signer-should-you-use-and-why)
+- [New account creation](https://docs.neynar.com/docs/how-to-create-a-new-farcaster-account-with-neynar)
+- [Webhooks](https://docs.neynar.com/docs/how-to-create-webhooks-on-the-go-using-the-sdk)
+- [Data ingestion pipelines](https://docs.neynar.com/docs/how-to-choose-the-right-data-product-for-you)
+
+🪐


### PR DESCRIPTION
Adding doc pages to create Feed, user profiles, conversation threads, etc. via Neynar

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces information about `Neynar`, a third-party service that provides various APIs and tools for developers working with `Farcaster`. It updates documentation to include an overview and links to relevant resources.

### Detailed summary
- Added a link to `Neynar` in `docs/reference/index.md`.
- Introduced a new section for `Third party services` in `docs/.vitepress/config.mts`.
- Created a new `Neynar` documentation page in `docs/reference/third-party/neynar/index.md` detailing services such as:
  - Hosted hubs
  - REST APIs
  - Signer management
  - New account creation
  - Webhooks
  - Data ingestion pipelines

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->