### PR TITLE
Fix (typo): fix typo in installation command

### DIFF
--- a/docs/developers/frames/getting-started.md
+++ b/docs/developers/frames/getting-started.md
@@ -39,7 +39,7 @@ pnpm create frog -t vercel
 Complete the prompts and follow the instructions:
 
 ```
-bun install // install depedencies
+bun install // install dependencies
 bun run dev // start dev server
 ```
 


### PR DESCRIPTION
This commit corrects the typo "depedencies" to "dependencies" in the installation command under the "Bootstrap via CLI" section of the "Getting Started with Frames" documentation. This improves clarity and accuracy of the documentation

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in the `docs/developers/frames/getting-started.md` file.

### Detailed summary
- Fixed the spelling of `depedencies` to `dependencies` in the comment for the `bun install` command.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->