### PR TITLE
Fix typo in documentation for Shuttle package

### DIFF
--- a/docs/developers/guides/apps/replicate.md
+++ b/docs/developers/guides/apps/replicate.md
@@ -10,6 +10,6 @@ While some applications can be written by directly querying Hubble, most serious
 in a more structured way.
 
 [Shuttle](https://github.com/farcasterxyz/hub-monorepo/tree/main/packages/shuttle) is a package
-be used to mirror Hubble's data to a Postgres DB for convenient access to the underlying data.
+used to mirror Hubble's data to a Postgres DB for convenient access to the underlying data.
 
 Check out the documentation for more information.


### PR DESCRIPTION
Corrected the phrase "be used" to "used" in the documentation for the Shuttle package to improve clarity and grammatical accuracy.