### PR TITLE
fix: typo correction viemConnector  client.md

### DIFF
--- a/docs/auth-kit/client/wallet/client.md
+++ b/docs/auth-kit/client/wallet/client.md
@@ -5,11 +5,11 @@ If you're building a [wallet app](https://docs.farcaster.xyz/learn/what-is-farca
 You can use a `WalletClient` to parse an incoming Sign In With Farcaster request URL, build a Sign In With Farcaster message to present to the user, and submit the signed message to a Farcaster Auth relay channel.
 
 ```ts
-import { createWalletClient, viemConnecter } from '@farcaster/auth-client';
+import { createWalletClient, viemConnector } from '@farcaster/auth-client';
 
 const walletClient = createWalletClient({
   relay: 'https://relay.farcaster.xyz',
-  ethereum: viemConnecter(),
+  ethereum: viemConnector(),
 });
 ```
 


### PR DESCRIPTION
Corrected viemConnecter to viemConnector to align with documentation at https://www.npmjs.com/package/@farcaster/auth-client.

![image](https://github.com/user-attachments/assets/dfcf0737-99f0-421e-9690-961b42ddc3bd)
![image](https://github.com/user-attachments/assets/721f270a-f5e4-48c6-94ea-87c7ed58d01b)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in the import statement and its usage in the `createWalletClient` function configuration. The `viemConnecter` is changed to `viemConnector`, ensuring consistency and potentially fixing a reference error.

### Detailed summary
- Changed `viemConnecter` to `viemConnector` in the import statement.
- Updated the `ethereum` property in the `createWalletClient` configuration from `viemConnecter()` to `viemConnector()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->