### PR TITLE
fix: Typo Corrections Across Documentation Files

### DIFF
--- a/docs/auth-kit/hooks/use-profile.md
+++ b/docs/auth-kit/hooks/use-profile.md
@@ -7,7 +7,7 @@ You can use this hook to read the authenticated user's profile information from 
 ```tsx
 import { useProfile } from '@farcaster/auth-kit';
 
-function App {
+function App() {
   const {
     isAuthenticated,
     profile: { username, fid, bio, displayName, pfpUrl },

--- a/docs/developers/frames/getting-started.md
+++ b/docs/developers/frames/getting-started.md
@@ -5,7 +5,7 @@ title: Getting Started with Frames
 # Getting Started
 
 ::: info Not ready to build?
-If you'd prefer to learn more about Frames before building one, jump ahead to the [Frames Specifcation](./spec).
+If you'd prefer to learn more about Frames before building one, jump ahead to the [Frames Specification](./spec).
 :::
 
 Let's use Frog to go from 0 to 1 in less than a minute. At the end of this we'll have:
@@ -39,7 +39,7 @@ pnpm create frog -t vercel
 Complete the prompts and follow the instructions:
 
 ```
-bun install // install depedencies
+bun install // install dependencies
 bun run dev // start dev server
 ```
 

--- a/docs/developers/frames/spec.md
+++ b/docs/developers/frames/spec.md
@@ -403,7 +403,7 @@ A signature packet is a JSON object sent to the Frame server when a button is cl
 
 1. **Signed Message** — an authenticated protobuf that represents the user action. This message must be unpacked by a farcaster hub to read the data inside.
 
-2. **Unsigned Message** — an unathenticated JSON object that represents the user action. can be read directly.
+2. **Unsigned Message** — an unauthenticated JSON object that represents the user action. can be read directly.
 
 ::: warning
 Unsigned messages can be spoofed and should usually be ignored. It is only safe to use them if you are performing an unauthenticated request.

--- a/docs/learn/what-is-farcaster/usernames.md
+++ b/docs/learn/what-is-farcaster/usernames.md
@@ -47,7 +47,7 @@ Choose an offchain ENS name if you want to get started quickly and don't have an
 - [UserData API](../../reference/hubble/httpapi/userdata) - Fetch the UserData for a user's current username.
 - [Username Proofs API](../../reference/hubble/httpapi/usernameproof) - Fetch a user's Username Proofs from a hub.
 - [Verification Proofs API](../../reference/hubble/httpapi/verification) - Fetch a user's Verifications from a hub.
-- [Fname Registry API](../../reference/fname/api.md) - Register and track fname ownership programatically.
+- [Fname Registry API](../../reference/fname/api.md) - Register and track fname ownership programmatically.
 
 ### Tutorials
 

--- a/docs/reference/contracts/deployments.md
+++ b/docs/reference/contracts/deployments.md
@@ -15,5 +15,4 @@ All Farcaster contracts are deployed on Optimism mainnet. There is no testnet de
 
 ## ABIs
 
-The ABIs for the contracts are available via etherscan links above, or from the
-the [`@farcaster/core`](https://github.com/farcasterxyz/hub-monorepo/tree/main/packages/core/src/eth/contracts/abis) package.
+The ABIs for the contracts are available via etherscan links above, or from the [`@farcaster/core`](https://github.com/farcasterxyz/hub-monorepo/tree/main/packages/core/src/eth/contracts/abis) package.

--- a/docs/reference/contracts/reference/bundler.md
+++ b/docs/reference/contracts/reference/bundler.md
@@ -52,7 +52,7 @@ The `SignerParams` struct includes signer key parameters and a KeyGateway [`Add`
 | key          | `bytes`   | Public key to add                                                                                                                 |
 | metadataType | `uint8`   | Must be set to `1`. This is currently the only supported `metadataType`.                                                          |
 | metadata     | `bytes`   | Encoded [`SignedKeyRequestMetadata`](/reference/contracts/reference/signed-key-request-validator#signedkeyrequestmetadata-struct) |
-| deadline     | `uint256` | Signature expiration timetamp                                                                                                     |
+| deadline     | `uint256` | Signature expiration timestamp                                                                                                     |
 | sig          | `bytes`   | EIP-712 [`Add`](/reference/contracts/reference/key-gateway#add-signature) signature from `registrationParams.to` address          |
 
 ## Errors

--- a/docs/reference/contracts/reference/id-registry.md
+++ b/docs/reference/contracts/reference/id-registry.md
@@ -304,7 +304,7 @@ the `owner` address in the following format:
 | from      | `address` | The previous recovery address       |
 | to        | `address` | The new recovery address            |
 | nonce     | `uint256` | Current nonce of the signer address |
-| deadline  | `uint256` | Signature expiraiton timestamp      |
+| deadline  | `uint256` | Signature expiration timestamp      |
 
 ::: code-group
 

--- a/docs/reference/hubble/datatypes/messages.md
+++ b/docs/reference/hubble/datatypes/messages.md
@@ -174,7 +174,7 @@ Type of Reaction
 
 ## 5. Link
 
-A Link message creates a relationship between two users (e..g follow)
+A Link message creates a relationship between two users (e.g. follow)
 
 ### 5.1 LinkBody
 

--- a/docs/reference/hubble/grpcapi/fids.md
+++ b/docs/reference/hubble/grpcapi/fids.md
@@ -20,5 +20,5 @@ Used to retrieve a list of all fids
 
 | Field           | Type            | Label    | Description    |
 | --------------- | --------------- | -------- | -------------- |
-| fids            | [uint64](#)     | repeated | Array oif fids |
+| fids            | [uint64](#)     | repeated | Array of fids |
 | next_page_token | [bytes](#bytes) | optional |                |

--- a/docs/reference/hubble/httpapi/userdata.md
+++ b/docs/reference/hubble/httpapi/userdata.md
@@ -18,7 +18,7 @@ Get UserData for a FID.
 | Parameter | Description | Example |
 | --------- | ----------- | ------- |
 | fid | The FID that's being requested | `fid=6833` |
-| user_data_type | The type of user data, either as a numerical value or type string. If this is ommited, all user data for the FID is returned| `user_data_type=1` OR `user_data_type=USER_DATA_TYPE_DISPLAY` |
+| user_data_type | The type of user data, either as a numerical value or type string. If this is omitted, all user data for the FID is returned| `user_data_type=1` OR `user_data_type=USER_DATA_TYPE_DISPLAY` |
 
 **Example**
 

--- a/docs/reference/warpcast/api.md
+++ b/docs/reference/warpcast/api.md
@@ -23,7 +23,7 @@ specify the page size.
 
 ## Authentication
 
-Authenticated endpoints use a self-signed token, signed an an App Key for FID:
+Authenticated endpoints use a self-signed token, signed as an App Key for FID:
 
 ```tsx
 import { NobleEd25519Signer } from "@farcaster/hub-nodejs";

--- a/docs/reference/warpcast/direct-casts.md
+++ b/docs/reference/warpcast/direct-casts.md
@@ -1,6 +1,6 @@
 # Direct Casts
 
-This page documents public APIs provided by Warpcast for direct casts. Direct casts are currently not part of the protcol. There are plans to add direct casts to the protocol later this year.
+This page documents public APIs provided by Warpcast for direct casts. Direct casts are currently not part of the protocol. There are plans to add direct casts to the protocol later this year.
 
 #### Send / write API for direct casts
 

--- a/docs/reference/warpcast/signer-requests.md
+++ b/docs/reference/warpcast/signer-requests.md
@@ -8,7 +8,7 @@ If your application wants to write data to Farcaster on behalf of a user, the ap
 
 - a registered FID
 
-### 1. An authenciated user clicks "Connect with Warpcast" in your app
+### 1. An authenticated user clicks "Connect with Warpcast" in your app
 
 Once your app can identify and authenticate a user you can present them with
 the option to connect with Warpcast.

--- a/docs/reference/warpcast/signers.md
+++ b/docs/reference/warpcast/signers.md
@@ -8,7 +8,7 @@ If your application wants to write data to Farcaster on behalf of a user, the ap
 
 - a registered FID
 
-#### 1. An authenciated user clicks "Connect with Warpcast" in your app
+#### 1. An authenticated user clicks "Connect with Warpcast" in your app
 
 Your app should be able to identify and authenticate a user before presenting
 them with the option to Connect with Warpcast.

--- a/docs/reference/warpcast/signers.md
+++ b/docs/reference/warpcast/signers.md
@@ -181,7 +181,7 @@ poll(token);
 
 When the user approves the request in Warpcast, an onchain transaction will be
 made that grants write permissions to that signer. Once that completes your app
-should indicate success and can being writing messages using the newly added key.
+should indicate success and can begin writing messages using the newly added key.
 
 #### Reference implementation
 
@@ -359,7 +359,7 @@ Get the state of a signed key requests.
 }
 ```
 
-**Sample response after after transaction is confirmed:**
+**Sample response after transaction is confirmed:**
 
 ```json
 {


### PR DESCRIPTION
Each file was carefully reviewed to ensure accuracy and clarity. The primary focus of these changes is to enhance the readability and professionalism of the documentation. No functional or structural changes have been made to the content.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting typographical errors and improving the clarity of documentation across various files related to the `farcaster` project.

### Detailed summary
- Fixed function declaration syntax in `docs/auth-kit/hooks/use-profile.md`.
- Corrected "authenciated" to "authenticated" in multiple files.
- Fixed "expiraiton" to "expiration" in `docs/reference/contracts/reference/id-registry.md` and `docs/reference/contracts/reference/bundler.md`.
- Corrected "ommitted" to "omitted" in `docs/reference/hubble/httpapi/userdata.md`.
- Fixed "unathenticated" to "unauthenticated" in `docs/developers/frames/spec.md`.
- Corrected "depedencies" to "dependencies" in `docs/developers/frames/getting-started.md`.
- Improved clarity in various documentation sections for better readability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->