### PR TITLE
Update signer-requests.md

### DIFF
--- a/docs/reference/warpcast/signer-requests.md
+++ b/docs/reference/warpcast/signer-requests.md
@@ -8,7 +8,7 @@ If your application wants to write data to Farcaster on behalf of a user, the ap
 
 - a registered FID
 
-### 1. An authenciated user clicks "Connect with Warpcast" in your app
+### 1. An authenticated user clicks "Connect with Warpcast" in your app
 
 Once your app can identify and authenticate a user you can present them with
 the option to connect with Warpcast.


### PR DESCRIPTION
### Spelling Error

<img width="601" alt="Снимок экрана 2024-10-31 в 19 51 20" src="https://github.com/user-attachments/assets/ccafb695-9a9b-4caf-8d8c-34b6df666f0c">

In the heading "An authenciated user clicks 'Connect with Warpcast' in your app," the word "authenciated" should be corrected to "**authenticated**."

Corrected.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in the documentation regarding user authentication in the `docs/reference/warpcast/signer-requests.md` file.

### Detailed summary
- Changed "authenciated" to "authenticated" in the section title.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->