### PR TITLE
Typo corrections

### DIFF
--- a/docs/auth-kit/sign-in-button.md
+++ b/docs/auth-kit/sign-in-button.md
@@ -22,7 +22,7 @@ export const Login = () => {
 
 | Prop               | Type       | Description                                                                         | Default               |
 | ------------------ | ---------- | ----------------------------------------------------------------------------------- | --------------------- |
-| `timeout`          | `number`   | Return an error after polling for this long.                                        | `300_000` (5 minutes) |
+| `timeout`          | `number`   | Return an error after polling for this long.                                        | `300000` (5 minutes) |
 | `interval`         | `number`   | Poll the relay server for updates at this interval.                                 | `1500` (1.5 seconds)  |
 | `nonce`            | `string`   | A random nonce to include in the Sign In With Farcaster message.                    | None                  |
 | `notBefore`        | `string`   | Time when the message becomes valid. ISO 8601 datetime string.                      | None                  |

--- a/docs/developers/frames/getting-started.md
+++ b/docs/developers/frames/getting-started.md
@@ -5,7 +5,7 @@ title: Getting Started with Frames
 # Getting Started
 
 ::: info Not ready to build?
-If you'd prefer to learn more about Frames before building one, jump ahead to the [Frames Specifcation](./spec).
+If you'd prefer to learn more about Frames before building one, jump ahead to the [Frames Specification](./spec).
 :::
 
 Let's use Frog to go from 0 to 1 in less than a minute. At the end of this we'll have:

--- a/docs/developers/frames/resources.md
+++ b/docs/developers/frames/resources.md
@@ -18,7 +18,7 @@ An opinionated collection of popular resources for building Frames.
 
 #### Frameworks
 
-- [frog](https://frog.fm) - minimal & lightweight framework Farcaster Frames
+- [frog](https://frog.fm) - minimal & lightweight framework for Farcaster Frames
 - [FrogUI](https://frog.fm/ui) - type-safe layout and styling primitives
 - [frames.js](https://framesjs.org/) - build, debug, and render Frames
 - [onchainkit](https://github.com/coinbase/onchainkit) - A React toolkit to create frames


### PR DESCRIPTION
### Description

Added typo corrections to documentation for the following files:

**docs/auth-kit/sign-in-button.md**

The correct value should be 300000 (without the underscore), representing 5 minutes.

Corrected.

**docs/developers/frames/getting-started.md**

"Specifcation" should be "Specification".

Corrected.

**docs/developers/frames/resources.md**

The typo in the text is in the phrase "minimal & lightweight framework Farcaster Frames". It is missing a preposition.

The correct phrase should be:

"minimal & lightweight framework for Farcaster Frames".

Corrected.

### Goal

Correct grammatical errors and improve readability of the documentation.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving documentation clarity by correcting typographical errors and enhancing descriptions in various Markdown files.

### Detailed summary
- Corrected "Frames Specifcation" to "Frames Specification" in `docs/developers/frames/getting-started.md`.
- Updated description for `frog` in `docs/developers/frames/resources.md` to include "for Farcaster Frames".
- Changed the default value format of `timeout` from `300_000` to `300000` in `docs/auth-kit/sign-in-button.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->