### PR TITLE
docs: update storage requirements

### DIFF
--- a/docs/hubble/hubble.md
+++ b/docs/hubble/hubble.md
@@ -9,8 +9,6 @@ the entire network. Messages uploaded to your Hubble instance will be broadcast 
 We recommend running Hubble if you are building an app, need access to the latest data or want to help decentralize the
 network.
 
-> ⚠️ **NOTE**: There are NO rewards for running a Hubble instance
-
 ## Hosted Instances
 
 Hubble instances can also be hosted for you by other service providers.

--- a/docs/hubble/install.md
+++ b/docs/hubble/install.md
@@ -8,10 +8,9 @@ Hubble can be set up in less than 30 minutes. You'll need a machine that has:
 
 - 16 GB of RAM
 - 4 CPU cores or vCPUs
-- 200 GB of free storage
+- 1TB of free storage
 - A public IP address with ports 2281 - 2283 exposed
-- RPC endpoints for Ethereum and Optimism Mainnet. (use [Alchemy](https://www.alchemy.com/), [Infura](https://www.infura.io/), [QuickNode](https://www.quicknode.com/), or run your own [Ethereum](https://geth.ethereum.org/docs/getting-started) & [Optimism](https://docs.optimism.io/builders/node-operators/tutorials/mainnet) nodes)
-  > ⚠️ **NOTE**: There's been a surge in Hubble users who violated [Alchemy Terms of Service](https://www.alchemy.com/terms-conditions/terms). As a result, [Alchemy](https://www.alchemy.com/) may block requests from new hubs. Paid subscriptions, alternative providers or your own nodes may be used instead. Please be aware that there are NO rewards or economic incentives for running a Hubble instance.
+- RPC endpoints for Ethereum and Optimism Mainnet. (use [Alchemy](https://www.alchemy.com/), [Infura](https://www.infura.io/), [QuickNode](https://www.quicknode.com/), or run your own [Ethereum](https://geth.ethereum.org/docs/getting-started) & [Optimism](https://docs.optimism.io/builders/node-operators/tutorials/mainnet) nodes).
 
 See [tutorials](./tutorials) for instructions on how to set up cloud providers to run Hubble.
 


### PR DESCRIPTION
The networks storage size is ~189 GB, but unzipping the initial snapshot may consume twice that space. It also increases over time, so bumping to 1TB which should provide enough headroom for the next year. 

<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the documentation for `Hubble`, specifically regarding hosted instances and system requirements.

### Detailed summary
- Updated storage requirement from `200 GB` to `1TB`.
- Added a note about potential request blocks from `Alchemy` due to user violations of terms.
- Clarified that there are no rewards for running a `Hubble` instance.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->