### PR TITLE
remove app frames date

### DIFF
--- a/docs/developers/frames/app-frames.md
+++ b/docs/developers/frames/app-frames.md
@@ -226,11 +226,3 @@ Prompt the user to follow a channel:
 ```tsx
 type FollowChannel = (options: { channelKey: string }) => Promise<void>;
 ```
-
-# FAQs
-
----
-
-**When can I start building an App Frame?**
-
-We are shooting to have an SDK and playground that developers can use to start building their App Frames by the end of next week (November 15th).


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the documentation for `app-frames` by adding a type definition and removing outdated FAQs related to building an App Frame.

### Detailed summary
- Added type definition for `FollowChannel` as a function that takes an options object with `channelKey` and returns a `Promise<void>`.
- Removed the FAQ section about when to start building an App Frame, including the specific date for SDK availability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->