### PR TITLE
Update replicate.md - typo

### DIFF
--- a/docs/developers/guides/apps/replicate.md
+++ b/docs/developers/guides/apps/replicate.md
@@ -10,6 +10,6 @@ While some applications can be written by directly querying Hubble, most serious
 in a more structured way.
 
 [Shuttle](https://github.com/farcasterxyz/hub-monorepo/tree/main/packages/shuttle) is a package
-be used to mirror Hubble's data to a Postgres DB for convenient access to the underlying data.
+that can be used to mirror Hubble's data to a Postgres DB for convenient access to the underlying data.
 
 Check out the documentation for more information.


### PR DESCRIPTION
Corrected a minor typo ("be used to" -> "that can be used to")

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation in `docs/developers/guides/apps/replicate.md` by improving the phrasing of a sentence regarding the `Shuttle` package.

### Detailed summary
- Changed the phrase "be used" to "that can be used" for clarity in the description of the `Shuttle` package.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->