### PR TITLE
chore: Update all references of 'Twitter' to 'X.com'

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -660,7 +660,7 @@ export default defineConfig({
         link: 'https://warpcast.com/~/channel/fc-devs' 
       },
       { icon: 'github', link: 'https://github.com/farcasterxyz/protocol' },
-      { icon: 'twitter', link: 'https://twitter.com/farcaster_xyz' },
+      { icon: 'twitter', link: 'https://x.com/farcaster_xyz' },
       { icon: 'youtube', link: 'https://www.youtube.com/@farcasterxyz' },
     ],
   },

--- a/docs/developers/guides/querying/fetch-channel-casts.md
+++ b/docs/developers/guides/querying/fetch-channel-casts.md
@@ -17,9 +17,9 @@ $ curl http://localhost:2281/v1/castsByParent\?fid\=1\&url\="https://ethereum.or
 "Pretty amazing that even during a bear market, the 30 day average burn gives us deflationary ETH. \n\nSource: Ultrasound.Money"
 "So, Ethereum is frequently called the Base Layer or L1 when talking about scalability.\n\nBut how can you call the whole Ethereum + Ethereum L2s + L3s that commit to Ethereum L2s?\n\nWe’re building a unified multi-chain explorer for that, but we don’t know how to call it: https://ethereum.routescan.io"
 "This, we're already doing.\n\nBut we call it, the Full-Index Ecosystem Explorer."
-". By subdomains do you mean more specific namespaces, e.g. Farcaster fnames being name.farcaster.eth?\n\nMy guess is if the root .eth namespace is available it will command higher status and value.\n\nhttps://twitter.com/0xfoobar/status/1687209523239604230"
+". By subdomains do you mean more specific namespaces, e.g. Farcaster fnames being name.farcaster.eth?\n\nMy guess is if the root .eth namespace is available it will command higher status and value.\n\nhttps://x.com/0xfoobar/status/1687209523239604230"
 "what are the best examples of DAOs with independent core working groups/multisigs?"
-"Anyone here use Rabby?\n\nhttps://twitter.com/0xfoobar/status/1687474090150416385"
+"Anyone here use Rabby?\n\nhttps://x.com/0xfoobar/status/1687474090150416385"
 "Who needs stablecoins when we have ETH"
 "782,672 active + pending validators! 🤯 \n\n(also... I haven't proposed a block for a few months)"
 ```
@@ -47,11 +47,11 @@ Using the GRPC API:
     '\n' +
     'My guess is if the root .eth namespace is available it will command higher status and value.\n' +
     '\n' +
-    'https://twitter.com/0xfoobar/status/1687209523239604230',
+    'https://x.com/0xfoobar/status/1687209523239604230',
   'what are the best examples of DAOs with independent core working groups/multisigs?',
   'Anyone here use Rabby?\n' +
     '\n' +
-    'https://twitter.com/0xfoobar/status/1687474090150416385',
+    'https://x.com/0xfoobar/status/1687474090150416385',
   'Who needs stablecoins when we have ETH',
   '782,672 active + pending validators! 🤯 \n' +
     '\n' +

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -2,7 +2,7 @@
 
 Farcaster is a [sufficiently decentralized](https://www.varunsrinivasan.com/2022/01/11/sufficient-decentralization-for-social-networks) social network built on Ethereum.
 
-It is a public social network similar to Twitter and Reddit. Users can create profiles, post "casts" and follow others. They own their accounts and relationships with other users and are free to move between different apps.
+It is a public social network similar to X and Reddit. Users can create profiles, post "casts" and follow others. They own their accounts and relationships with other users and are free to move between different apps.
 
 :::tip Join Farcaster
 If you're not on Farcaster, get started by [creating your account](https://www.warpcast.com/) with Warpcast.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR primarily updates links and references from `twitter.com` to `x.com`, reflecting the rebranding of Twitter. It also modifies a description in the documentation to replace mentions of Twitter with X.

### Detailed summary
- Updated link for `twitter` icon in `docs/.vitepress/config.mts` from `https://twitter.com/farcaster_xyz` to `https://x.com/farcaster_xyz`.
- Changed description in `docs/learn/index.md` from "Twitter" to "X".
- Updated URLs in `docs/developers/guides/querying/fetch-channel-casts.md` from `twitter.com` to `x.com`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->