### PR TITLE
Remove stray comma that causes type errors

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -413,7 +413,6 @@ export default defineConfig({
                       text: 'verifySignInMessage',
                       link: '/auth-kit/client/app/verify-sign-in-message',
                     },
-                    ,
                   ],
                 },
                 {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the configuration file for the documentation site, specifically adjusting the route linking for the `verify-sign-in-message`.

### Detailed summary
- Removed an empty line in `docs/.vitepress/config.mts`.
- Updated the route link for `verify-sign-in-message` in the configuration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->