### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docs/auth-kit/client/wallet/client.md
+++ b/docs/auth-kit/client/wallet/client.md
@@ -5,11 +5,11 @@ If you're building a [wallet app](https://docs.farcaster.xyz/learn/what-is-farca
 You can use a `WalletClient` to parse an incoming Sign In With Farcaster request URL, build a Sign In With Farcaster message to present to the user, and submit the signed message to a Farcaster Auth relay channel.
 
 ```ts
-import { createWalletClient, viemConnecter } from '@farcaster/auth-client';
+import { createWalletClient, viemConnector } from '@farcaster/auth-client';
 
 const walletClient = createWalletClient({
   relay: 'https://relay.farcaster.xyz',
-  ethereum: viemConnecter(),
+  ethereum: viemConnector(),
 });
 ```
 

--- a/docs/developers/frames/getting-started.md
+++ b/docs/developers/frames/getting-started.md
@@ -5,7 +5,7 @@ title: Getting Started with Frames
 # Getting Started
 
 ::: info Not ready to build?
-If you'd prefer to learn more about Frames before building one, jump ahead to the [Frames Specifcation](./spec).
+If you'd prefer to learn more about Frames before building one, jump ahead to the [Frames Specification](./spec).
 :::
 
 Let's use Frog to go from 0 to 1 in less than a minute. At the end of this we'll have:
@@ -39,7 +39,7 @@ pnpm create frog -t vercel
 Complete the prompts and follow the instructions:
 
 ```
-bun install // install depedencies
+bun install // install dependencies
 bun run dev // start dev server
 ```
 

--- a/docs/developers/frames/spec.md
+++ b/docs/developers/frames/spec.md
@@ -403,7 +403,7 @@ A signature packet is a JSON object sent to the Frame server when a button is cl
 
 1. **Signed Message** — an authenticated protobuf that represents the user action. This message must be unpacked by a farcaster hub to read the data inside.
 
-2. **Unsigned Message** — an unathenticated JSON object that represents the user action. can be read directly.
+2. **Unsigned Message** — an unauthenticated JSON object that represents the user action. can be read directly.
 
 ::: warning
 Unsigned messages can be spoofed and should usually be ignored. It is only safe to use them if you are performing an unauthenticated request.

--- a/docs/learn/what-is-farcaster/usernames.md
+++ b/docs/learn/what-is-farcaster/usernames.md
@@ -47,7 +47,7 @@ Choose an offchain ENS name if you want to get started quickly and don't have an
 - [UserData API](../../reference/hubble/httpapi/userdata) - Fetch the UserData for a user's current username.
 - [Username Proofs API](../../reference/hubble/httpapi/usernameproof) - Fetch a user's Username Proofs from a hub.
 - [Verification Proofs API](../../reference/hubble/httpapi/verification) - Fetch a user's Verifications from a hub.
-- [Fname Registry API](../../reference/fname/api.md) - Register and track fname ownership programatically.
+- [Fname Registry API](../../reference/fname/api.md) - Register and track fname ownership programmatically.
 
 ### Tutorials
 

--- a/docs/reference/contracts/reference/bundler.md
+++ b/docs/reference/contracts/reference/bundler.md
@@ -52,7 +52,7 @@ The `SignerParams` struct includes signer key parameters and a KeyGateway [`Add`
 | key          | `bytes`   | Public key to add                                                                                                                 |
 | metadataType | `uint8`   | Must be set to `1`. This is currently the only supported `metadataType`.                                                          |
 | metadata     | `bytes`   | Encoded [`SignedKeyRequestMetadata`](/reference/contracts/reference/signed-key-request-validator#signedkeyrequestmetadata-struct) |
-| deadline     | `uint256` | Signature expiration timetamp                                                                                                     |
+| deadline     | `uint256` | Signature expiration timestamp                                                                                                     |
 | sig          | `bytes`   | EIP-712 [`Add`](/reference/contracts/reference/key-gateway#add-signature) signature from `registrationParams.to` address          |
 
 ## Errors

--- a/docs/reference/contracts/reference/id-registry.md
+++ b/docs/reference/contracts/reference/id-registry.md
@@ -304,7 +304,7 @@ the `owner` address in the following format:
 | from      | `address` | The previous recovery address       |
 | to        | `address` | The new recovery address            |
 | nonce     | `uint256` | Current nonce of the signer address |
-| deadline  | `uint256` | Signature expiraiton timestamp      |
+| deadline  | `uint256` | Signature expiration timestamp      |
 
 ::: code-group
 

--- a/docs/reference/hubble/httpapi/userdata.md
+++ b/docs/reference/hubble/httpapi/userdata.md
@@ -18,7 +18,7 @@ Get UserData for a FID.
 | Parameter | Description | Example |
 | --------- | ----------- | ------- |
 | fid | The FID that's being requested | `fid=6833` |
-| user_data_type | The type of user data, either as a numerical value or type string. If this is ommited, all user data for the FID is returned| `user_data_type=1` OR `user_data_type=USER_DATA_TYPE_DISPLAY` |
+| user_data_type | The type of user data, either as a numerical value or type string. If this is omitted, all user data for the FID is returned| `user_data_type=1` OR `user_data_type=USER_DATA_TYPE_DISPLAY` |
 
 **Example**
 

--- a/docs/reference/warpcast/direct-casts.md
+++ b/docs/reference/warpcast/direct-casts.md
@@ -1,6 +1,6 @@
 # Direct Casts
 
-This page documents public APIs provided by Warpcast for direct casts. Direct casts are currently not part of the protcol. There are plans to add direct casts to the protocol later this year.
+This page documents public APIs provided by Warpcast for direct casts. Direct casts are currently not part of the protocol. There are plans to add direct casts to the protocol later this year.
 
 #### Send / write API for direct casts
 

--- a/docs/reference/warpcast/signer-requests.md
+++ b/docs/reference/warpcast/signer-requests.md
@@ -8,7 +8,7 @@ If your application wants to write data to Farcaster on behalf of a user, the ap
 
 - a registered FID
 
-### 1. An authenciated user clicks "Connect with Warpcast" in your app
+### 1. An authenticated user clicks "Connect with Warpcast" in your app
 
 Once your app can identify and authenticate a user you can present them with
 the option to connect with Warpcast.

--- a/docs/reference/warpcast/signers.md
+++ b/docs/reference/warpcast/signers.md
@@ -8,7 +8,7 @@ If your application wants to write data to Farcaster on behalf of a user, the ap
 
 - a registered FID
 
-#### 1. An authenciated user clicks "Connect with Warpcast" in your app
+#### 1. An authenticated user clicks "Connect with Warpcast" in your app
 
 Your app should be able to identify and authenticate a user before presenting
 them with the option to Connect with Warpcast.


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `viemConnecter` to `viemConnector` x2.
Corrected `Specifcation` to `Specification`
Corrected `depedencies` to `dependencies`
Corrected `unathenticated` to `unauthenticated`
Corrected `programatically` to `programmatically`
Corrected `timetamp` to `timestamp`
Corrected `expiraiton` to `expiration`
Corrected `ommited` to `omitted`
Corrected `protcol` to `protocol`
Corrected `authenciated` to `authenticated` x2.

Please review the changes and let me know if any additional changes are needed.
