### PR TITLE
Clarify that webhookUrl is required for notifications to work

### DIFF
--- a/docs/developers/frames/v2/spec.md
+++ b/docs/developers/frames/v2/spec.md
@@ -516,6 +516,8 @@ The Farcaster client server POSTs 4 types of events to the frame server at the `
 - `notifications-enabled`
 - `notifications-disabled`
 
+Your endpoint should return a 200 response. It is up to Farcaster clients how often and for how long they retry in case of errors.
+
 The body looks like this:
 
 Events use the [JSON Farcaster Signature](https://github.com/farcasterxyz/protocol/discussions/208) format and are signed with the app key of the user. The final format is:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the documentation for the Farcaster framework, clarifying the requirements and processes for handling notifications and domain manifests.

### Detailed summary
- Removed `notifications-disabled` mention.
- Clarified response requirements for endpoints.
- Emphasized the necessity of `webhookUrl` for sending notifications.
- Updated the format for a valid domain manifest.
- Improved clarity on how to receive notification tokens and URLs.
- Simplified language regarding rate limits for tokens.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->