### PR TITLE
Clarify that frame notifications are in-app and not push

### DIFF
--- a/docs/developers/frames/v2/notifications_webhooks.md
+++ b/docs/developers/frames/v2/notifications_webhooks.md
@@ -6,6 +6,8 @@ title: Frames v2 Notifications & Webhooks
 
 Frames v2 allow developers to send notifications to users who have "added" the frame to their Farcaster client and enabled notifications.
 
+In Warpcast, these are **in-app notifications** that trigger the red on the notifications tab. At this stage there is no support for push notifications.
+
 The steps to successfully send a notification are:
 
 1. Sets a valid domain manifest so that the frame is eligible to be added to a Farcaster client and use notifications.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the documentation for `Frames v2` regarding how developers can send notifications to users in the `Farcaster` client, specifically highlighting the functionality of in-app notifications.

### Detailed summary
- Added information about **in-app notifications** in `Warpcast` that trigger the red indicator on the notifications tab.
- Clarified that there is currently no support for push notifications.
- Included a step for setting a valid domain manifest for notification eligibility.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->