### PR TITLE
Fix missing `s` in frame notifications url

### DIFF
--- a/docs/developers/frames/v2/notifications_webhooks.md
+++ b/docs/developers/frames/v2/notifications_webhooks.md
@@ -221,7 +221,7 @@ Webhook payload:
 {
   "event": "frame-added",
   "notificationDetails": {
-    "url": "https://api.warpcast.com/v1/frame-notification",
+    "url": "https://api.warpcast.com/v1/frame-notifications",
     "token": "a05059ef2415c67b08ecceb539201cbc6"
   }
 }
@@ -268,7 +268,7 @@ Webhook payload:
 {
   "event": "notifications-enabled",
   "notificationDetails": {
-    "url": "https://api.warpcast.com/v1/frame-notification",
+    "url": "https://api.warpcast.com/v1/frame-notifications",
     "token": "a05059ef2415c67b08ecceb539201cbc6"
   }
 }

--- a/docs/developers/frames/v2/spec.md
+++ b/docs/developers/frames/v2/spec.md
@@ -473,7 +473,7 @@ Request the user to add the frame, which adds it to the user's favorites list an
 {
   "type": "success",
   "notificationDetails": {
-    "url": "https://api.warpcast.com/v1/frame-notification",
+    "url": "https://api.warpcast.com/v1/frame-notifications",
     "token": "a05059ef2415c67b08ecceb539201cbc6"
   }
 }
@@ -550,7 +550,7 @@ Webhook payload:
 {
   "event": "frame-added",
   "notificationDetails": {
-    "url": "https://api.warpcast.com/v1/frame-notification",
+    "url": "https://api.warpcast.com/v1/frame-notifications",
     "token": "a05059ef2415c67b08ecceb539201cbc6"
   }
 }
@@ -603,7 +603,7 @@ Webhook payload:
 {
   "event": "notifications-enabled",
   "notificationDetails": {
-    "url": "https://api.warpcast.com/v1/frame-notification",
+    "url": "https://api.warpcast.com/v1/frame-notifications",
     "token": "a05059ef2415c67b08ecceb539201cbc6"
   }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the URL for frame notifications in the documentation to ensure consistency across multiple webhook payload examples.

### Detailed summary
- Changed the URL from `https://api.warpcast.com/v1/frame-notification` to `https://api.warpcast.com/v1/frame-notifications` in:
  - `docs/developers/frames/v2/notifications_webhooks.md`
  - `docs/developers/frames/v2/spec.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->