### PR TITLE
docs: typo fixes Update getting-started.md

### DIFF
--- a/docs/developers/frames/getting-started.md
+++ b/docs/developers/frames/getting-started.md
@@ -5,7 +5,7 @@ title: Getting Started with Frames
 # Getting Started
 
 ::: info Not ready to build?
-If you'd prefer to learn more about Frames before building one, jump ahead to the [Frames Specifcation](./spec).
+If you'd prefer to learn more about Frames before building one, jump ahead to the [Frames Specification](./spec).
 :::
 
 Let's use Frog to go from 0 to 1 in less than a minute. At the end of this we'll have:
@@ -39,7 +39,7 @@ pnpm create frog -t vercel
 Complete the prompts and follow the instructions:
 
 ```
-bun install // install depedencies
+bun install // install dependencies
 bun run dev // start dev server
 ```
 


### PR DESCRIPTION
A couple of typographical errors in the documentation that could cause confusion or make the text less professional.

1. In the section `::: info Not ready to build?`, the word "Specifcation" was misspelled. The correct spelling is **Specification**.
   
2. In the section `Complete the prompts and follow the instructions`, the word "depedencies" was incorrectly spelled. The correct spelling is **dependencies**.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting minor typographical errors in the documentation for getting started with `Frames`. 

### Detailed summary
- Changed "Frames Specifcation" to "Frames Specification" in `docs/developers/frames/getting-started.md`.
- Corrected "depedencies" to "dependencies" in the installation command section.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->