### PR TITLE
Fix Minor Typographical Errors in Documentation

### DIFF
--- a/docs/learn/what-is-farcaster/messages.md
+++ b/docs/learn/what-is-farcaster/messages.md
@@ -70,4 +70,4 @@ Timestamps are unverified and can be backdated by users, similar to a blog post.
 - [Get casts](../../developers/guides/querying/fetch-casts) - Get an account's casts from a hub.
 - [Get profile](../../developers/guides/querying/fetch-profile) - Get an account's profile from a hub.
 - [Create common message types](../../developers/guides/writing/messages) - Create casts, links, reactions and userdata.
-- [Create casts with advanced features](../../developers/guides/writing/casts) - Create casts with embeds, emoji and mentions.
+- [Create casts with advanced features](../../developers/guides/writing/casts) - Create casts with embeds, emojis and mentions.

--- a/docs/learn/what-is-farcaster/usernames.md
+++ b/docs/learn/what-is-farcaster/usernames.md
@@ -47,7 +47,7 @@ Choose an offchain ENS name if you want to get started quickly and don't have an
 - [UserData API](../../reference/hubble/httpapi/userdata) - Fetch the UserData for a user's current username.
 - [Username Proofs API](../../reference/hubble/httpapi/usernameproof) - Fetch a user's Username Proofs from a hub.
 - [Verification Proofs API](../../reference/hubble/httpapi/verification) - Fetch a user's Verifications from a hub.
-- [Fname Registry API](../../reference/fname/api.md) - Register and track fname ownership programatically.
+- [Fname Registry API](../../reference/fname/api.md) - Register and track fname ownership programmatically.
 
 ### Tutorials
 


### PR DESCRIPTION
### Description:  

Two typographical issues in the Farcaster documentation to improve clarity and maintain professional standards:  

1. **File:** `docs/learn/what-is-farcaster/messages.md`  
   **Issue:** In the phrase *"Create casts with embeds, emoji and mentions,"* the word "emoji" should align with the plural context as "emojis."  
   **Fix:** Updated "emoji" to "emojis" for grammatical consistency and better readability.  

2. **File:** `docs/learn/what-is-farcaster/usernames.md`  
   **Issue:** In the phrase *"Fname Registry API - Register and track fname ownership programatically,"* the word "programatically" was misspelled.  
   **Fix:** Corrected the spelling to "programmatically" to ensure accuracy.  

**Thanks for review!**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting minor typographical errors in the documentation related to the `Fname Registry API` and the `Create casts with advanced features` section.

### Detailed summary
- Changed "programatically" to "programmatically" in `usernames.md`.
- Changed "emoji" to "emojis" in `messages.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->