### PR TITLE
docs: Correct post command and heading errors

### DIFF
--- a/docs/reference/hubble/datatypes/messages.md
+++ b/docs/reference/hubble/datatypes/messages.md
@@ -17,7 +17,7 @@ The message is a protobuf that contains the data, its hash and a signature from 
 | signature        | bytes                               |       | Signature of the hash digest                                                                                                                                                                                                                                    |
 | signature_scheme | [SignatureScheme](#SignatureScheme) |       | Signature scheme that produced the signature                                                                                                                                                                                                                    |
 | signer           | bytes                               |       | Public key or address of the key pair that produced the signature                                                                                                                                                                                               |
-| data_bytes       | bytes                               |       | Alternate to the "data" field. If you are constructing the [MessageData](#MessageData) in a programing language other than Typescript, you can use this field to serialize the `MessageData` and calculate the `hash` and `signature` on these bytes. Optional. |
+| data_bytes       | bytes                               |       | Alternate to the "data" field. If you are constructing the [MessageData](#MessageData) in a programming language other than Typescript, you can use this field to serialize the `MessageData` and calculate the `hash` and `signature` on these bytes. Optional. |
 
 ### 1.1 MessageData
 

--- a/docs/reference/hubble/httpapi/message.md
+++ b/docs/reference/hubble/httpapi/message.md
@@ -154,7 +154,7 @@ curl -X POST "http://127.0.0.1:2281/v1/validateMessage" \
 }
 ```
 
-## Using with Rust, Go or other programing languages
+## Using with Rust, Go or other programming languages
 
 Messages need to be signed with a Ed25519 account key belonging to the FID. If you are using a different programming
 language


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on correcting spelling errors in the documentation related to programming languages and the `data_bytes` field.

### Detailed summary
- Changed the heading from "programing languages" to "programming languages" in `docs/reference/hubble/httpapi/message.md`.
- Updated the description of the `data_bytes` field to correct "programing language" to "programming language" in `docs/reference/hubble/datatypes/messages.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->