### PR TITLE
PR fixing issue #2394

### DIFF
--- a/docs/developers/frames/getting-started.md
+++ b/docs/developers/frames/getting-started.md
@@ -39,7 +39,7 @@ pnpm create frog -t vercel
 Complete the prompts and follow the instructions:
 
 ```
-bun install // install depedencies
+bun install // install dependencies
 bun run dev // start dev server
 ```
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on correcting a typo in the documentation related to the `bun install` command.

### Detailed summary
- Changed `depedencies` to `dependencies` in the comment for the `bun install` command in `docs/developers/frames/getting-started.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->