### PR TITLE
Mention @farcaster/frame-node as a package to handle webhooks

### DIFF
--- a/docs/developers/frames/v2/notifications_webhooks.md
+++ b/docs/developers/frames/v2/notifications_webhooks.md
@@ -16,6 +16,12 @@ The steps to successfully send a notification are:
 4. Send a notification by POSTing to the `url` using the `token`
 5. Listen for webhooks that tell you when a user adds/removes the frame and enables/disables notifications
 
+The [Frames V2 Demo frame](https://github.com/farcasterxyz/frames-v2-demo) has all of the above:
+
+- [Handles webhooks](<(https://github.com/farcasterxyz/frames-v2-demo/blob/main/src/app/api/webhook/route.ts)>) leveraging the [`@farcaster/frame-node`](https://github.com/farcasterxyz/frames/tree/main/packages/frame-node) library that makes this very easy
+- [Saves notification tokens to Redis](https://github.com/farcasterxyz/frames-v2-demo/blob/main/src/lib/kv.ts)
+- [Sends notifications](https://github.com/farcasterxyz/frames-v2-demo/blob/main/src/lib/notifs.ts)
+
 ## Create a Farcaster Domain Manifest
 
 A Farcaster domain manifest is required for a frame to be eligible to be added to Farcaster clients and send notifications. It looks like this:
@@ -185,7 +191,7 @@ The `header` JSON has 3 properties:
 
 The `payload` JSON differs per event, see below.
 
-[Example code to process webhook events](https://github.com/farcasterxyz/frames-v2-demo/blob/7905a24b7cd254a77a7e1a541288379b444bc23e/src/app/api/webhook/route.ts)
+The [`@farcaster/frame-node`](https://github.com/farcasterxyz/frames/tree/main/packages/frame-node) library makes handling very easy. The only thing it requires is a method that validates that the app key belongs to the FID and returns the Farcaster client FID. An implementation that uses [Neynar](https://neynar.com) is provided. Check out the [README](https://github.com/farcasterxyz/frames/tree/main/packages/frame-node) and [see how it's used in the Frames V2 Demo frame](https://github.com/farcasterxyz/frames-v2-demo/blob/main/src/app/api/webhook/route.ts).
 
 ### `frame_added`: frame added to a client
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the documentation for `Frames V2` by providing more detailed information about handling webhooks and utilizing the `@farcaster/frame-node` library. It emphasizes the `Frames V2 Demo frame` and its capabilities.

### Detailed summary
- Added a section on the `Frames V2 Demo frame`, highlighting its features.
- Included links to specific implementations for handling webhooks, saving notification tokens to `Redis`, and sending notifications.
- Clarified the requirements for validating app keys and using the `@farcaster/frame-node` library.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->