### PR TITLE
Fix Typos and Improve Hyphenation in Documentation  

### DIFF
--- a/docs/auth-kit/client/introduction.md
+++ b/docs/auth-kit/client/introduction.md
@@ -2,7 +2,7 @@
 
 [![NPM Version](https://img.shields.io/npm/v/@farcaster/auth-client)](https://www.npmjs.com/package/@farcaster/auth-client)
 
-The `@farcaster/auth-client` library provides a framework agnostic client for Farcaster Auth. If you're not using React, want greater customizability, or want to interact with the Farcaster Auth relay directly, you can use the Auth client library to build your own Sign in With Farcaster flow.
+The `@farcaster/auth-client` library provides a framework-agnostic client for Farcaster Auth. If you're not using React, want greater customizability, or want to interact with the Farcaster Auth relay directly, you can use the Auth client library to build your own Sign in With Farcaster flow.
 
 ## Getting Started
 

--- a/docs/developers/frames/index.md
+++ b/docs/developers/frames/index.md
@@ -30,7 +30,7 @@ Warpcast will continue to support Frames v1 through at least March 2025.
 
 ### Farcaster 101
 
-A 5 minute non-technical primer on Frames:
+A 5-minute non-technical primer on Frames:
 
 <iframe width="688" height="387" src="https://www.youtube.com/embed/rp9X8rAPzPM?si=aXLuh4BBonkm4pKj" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -12,7 +12,7 @@ If you're not on Farcaster, get started by [creating your account](https://www.w
 
 If you want to learn more, get started by diving into these concepts:
 
-- [Farcaster 101](https://www.youtube.com/playlist?list=PL0eq1PLf6eUdm35v_840EGLXkVJDhxhcF) - a walkthrough of the Farcaster protocol in short, 5 minute videos.
+- [Farcaster 101](https://www.youtube.com/playlist?list=PL0eq1PLf6eUdm35v_840EGLXkVJDhxhcF) - a walkthrough of the Farcaster protocol in short, 5-minute videos.
 - [Core Concepts](/learn/what-is-farcaster/accounts) - learn about the building blocks of Farcaster, starting with accounts.
 - [Architecture](/learn/architecture/overview) - a breakdown of Farcaster's onchain and offchain systems.
 


### PR DESCRIPTION
This PR addresses minor typos and improves consistency in hyphenation across several documentation files. 

Specifically:  

## Changes Made  

1. **`docs/auth-kit/client/introduction.md`**  
   - Corrected "framework agnostic" to "framework-agnostic" for proper hyphenation.

2. **`docs/developers/frames/index.md`**  
   - Updated "5 minute" to "5-minute" to follow standard compound adjective rules.

3. **`docs/learn/index.md`**  
   - Revised "5 minute videos" to "5-minute videos" for consistency in hyphenation.  

These changes enhance the clarity and professionalism of the documentation while adhering to standard English grammar rules.  

---

- **Files Changed:** 3  
- **Commits:** 3  

Please let me know if further adjustments are needed.  
**Allow edits by maintainers:** Enabled.
