### PR TITLE
update frame devtools link

### DIFF
--- a/docs/developers/frames/v2/resources.md
+++ b/docs/developers/frames/v2/resources.md
@@ -23,7 +23,7 @@ title: Frames v2 Resources
 
 ### Tools
 
-- [Frame Playground](https://warpcast.com/~/developers/frame-playground) - Frame developer tools (Warpcast mobile only)
+- [Frame Playground](https://warpcast.com/~/developers/frames) - Warpcast Frame developer tools
 - [Frame SDK](https://github.com/farcasterxyz/frames/) - Frame SDK JavaScript library
 
 #### Learning


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the documentation for the `Frame Playground`, correcting the link and improving the description for clarity.

### Detailed summary
- Updated the link for `Frame Playground` from `https://warpcast.com/~/developers/frame-playground` to `https://warpcast.com/~/developers/frames`.
- Revised the description of `Frame Playground` to specify it as "Warpcast Frame developer tools".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->