### PR TITLE
fix link

### DIFF
--- a/docs/developers/frames/v2/notifications_webhooks.md
+++ b/docs/developers/frames/v2/notifications_webhooks.md
@@ -18,7 +18,7 @@ The steps to successfully send a notification are:
 
 The [Frames V2 Demo frame](https://github.com/farcasterxyz/frames-v2-demo) has all of the above:
 
-- [Handles webhooks](<(https://github.com/farcasterxyz/frames-v2-demo/blob/main/src/app/api/webhook/route.ts)>) leveraging the [`@farcaster/frame-node`](https://github.com/farcasterxyz/frames/tree/main/packages/frame-node) library that makes this very easy
+- [Handles webhooks](https://github.com/farcasterxyz/frames-v2-demo/blob/main/src/app/api/webhook/route.ts) leveraging the [`@farcaster/frame-node`](https://github.com/farcasterxyz/frames/tree/main/packages/frame-node) library that makes this very easy
 - [Saves notification tokens to Redis](https://github.com/farcasterxyz/frames-v2-demo/blob/main/src/lib/kv.ts)
 - [Sends notifications](https://github.com/farcasterxyz/frames-v2-demo/blob/main/src/lib/notifs.ts)
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the documentation for the `Frames V2 Demo frame`, specifically correcting a link formatting issue related to webhooks.

### Detailed summary
- Fixed the link format for webhooks in the documentation, changing from a broken link syntax to a proper hyperlink.
- No changes were made to the content about saving notification tokens to Redis or sending notifications.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->