### PR TITLE
Document imageUrl and buttonTitle manifest fields

### DIFF
--- a/docs/developers/frames/v2/notifications_webhooks.md
+++ b/docs/developers/frames/v2/notifications_webhooks.md
@@ -30,17 +30,19 @@ A Farcaster domain manifest is required for a frame to be eligible to be added t
 {
   "accountAssociation": {
     "header": "eyJmaWQiOjU0NDgsInR5cGUiOiJjdXN0b2R5Iiwia2V5IjoiMHg2MWQwMEFENzYwNjhGOEQ0NzQwYzM1OEM4QzAzYUFFYjUxMGI1OTBEIn0",
-    "payload": "eyJkb21haW4iOiJ0ZXN0In0",
-    "signature": "MHhlZWJkZjlhNDgwMWI2YTExNTc2MjdiZDg2OTM3YTAxN2ZlMzFhMzQ2Njk1YjMxZjFmZTFhOWYzZGUyNjY0MjEwNGJiMDRlMGJlNDdmZjg4YWE4NjIzOWUwZTg1MDc4MDQzNDdmNGUxNmUwMDAwOTUzY2VhMGQwMDdhNDEwMTBjZDFj"
+    "payload": "eyJkb21haW4iOiJleGFtcGxlLmNvbSJ9",
+    "signature": "MHg3NmRkOWVlMjE4OGEyMjliNzExZjUzOTkxYTc1NmEzMGZjNTA3NmE5OTU5OWJmOWFmYjYyMzAyZWQxMWQ2MWFmNTExYzlhYWVjNjQ3OWMzODcyMTI5MzA2YmJhYjdhMTE0MmRhMjA4MmNjNTM5MTJiY2MyMDRhMWFjZTY2NjE5OTFj"
   },
   "frame": {
+    "version": "1",
     "name": "Example Frame",
-    "version": "0.0.1",
     "iconUrl": "https://example.com/icon.png",
     "homeUrl": "https://example.com",
+    "imageUrl": "https://example.com/image.png",
+    "buttonTitle": "Check this out",
     "splashImageUrl": "https://example.com/splash.png",
     "splashBackgroundColor": "#eeccff",
-    "webhookUrl": "https://example.com/webhook"
+    "webhookUrl": "https://example.com/api/webhook"
   }
 }
 ```

--- a/docs/developers/frames/v2/spec.md
+++ b/docs/developers/frames/v2/spec.md
@@ -151,6 +151,17 @@ type FrameConfig = {
   // Example: "https://yoink.party/img/icon.png"
   iconUrl: string;
 
+  // Default image to show when frame is rendered in a feed.
+  // Max 512 characters.
+  // Image must have a 3:2 ratio.
+  // Example: "https://yoink.party/framesV2/opengraph-image"
+  imageUrl: string;
+
+  // Default button title to use when frame is rendered in a feed.
+  // Max 32 characters.
+  // Example: "🚩 Start"
+  buttonTitle: string;
+
   // Splash image URL.
   // Max 512 characters.
   // Image must be 200x200px and less than 1MB.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces new properties and updates existing ones in the `spec.md` and `notifications_webhooks.md` files related to frame specifications and webhook payloads.

### Detailed summary
- Added `imageUrl` property with specifications for default images.
- Added `buttonTitle` property with specifications for button titles.
- Updated `payload` in `accountAssociation` to a new example value.
- Updated `signature` in `accountAssociation` to a new example value.
- Changed `version` in `frame` from `0.0.1` to `1`.
- Updated `webhookUrl` in `frame` to a new API endpoint.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->