### PR TITLE
 improve clarity

### DIFF
--- a/docs/learn/what-is-farcaster/channels.md
+++ b/docs/learn/what-is-farcaster/channels.md
@@ -10,7 +10,7 @@ Channels are being prototyped in Warpcast and not fully supported by the Farcast
 
 ## Hosting Channels
 
-Anyone can create a channel host by paying a fee in Warpcast and choosing a channel name. The name must be under 16 characters and can only contain lowercase alphabets and numbers. A channel's creator is called a host and may invite other co-hosts to operate the channel. Hosts have special privileges like:
+Anyone can create a channel host by paying a fee in Warpcast and choosing a channel name. The name must be under 16 characters and can only contain lowercase letters and numbers. A channel's creator is called a host and may invite other co-hosts to operate the channel. Hosts have special privileges like:
 
 1. Defining “channel norms" which everyone must agree to when joining.
 2. Pinning or hiding casts in a channel.

--- a/docs/learn/what-is-farcaster/messages.md
+++ b/docs/learn/what-is-farcaster/messages.md
@@ -4,7 +4,7 @@ Farcaster accounts interact by signing and publishing messages. Alice can create
 
 Messages are stored on a peer-to-peer network of nodes. A node in the Farcaster network is called a Hub, and each Hub stores a copy of the entire network. A user can publish a message to one Hub and it will propagate to the entire network in a few seconds. Farcaster's compact message format and eventually consistent model lets this architecture scale to millions of users.
 
-An account can generate a [key](./accounts.md#adding-account-keys) and give it to an app which can use it to sign messages. Users can use multiple apps with the same account, and each application can have its own key. Separating the signing keys from the ownership keys helps keep the account secure.
+An account can generate a [key](./accounts.md#adding-account-keys) and give it to an app that can use it to sign messages. Users can use multiple apps with the same account, and each application can have its own key. Separating the signing keys from the ownership keys helps keep the account secure.
 
 ## Types
 

--- a/docs/reference/hubble/datatypes/events.md
+++ b/docs/reference/hubble/datatypes/events.md
@@ -2,9 +2,9 @@
 
 Events represent state changes, like a new message or contract event.
 
-Hubble emit events whenever it observes a state change. Since a hub may see messages in a different order than other hubs, events ordering is specific to each hub. Clients can subscribe to the hub using the [Events API](/reference/hubble/grpcapi/events) to get a live stream of changes to the hub.
+Hubble emits events whenever it observes a state change. Since a hub may see messages in a different order than other hubs, events ordering is specific to each hub. Clients can subscribe to the hub using the [Events API](/reference/hubble/grpcapi/events) to get a live stream of changes to the hub.
 
-Hubble keeps event around for 3 days after which they are deleted to save space. To get older data, use the [GRPC](../grpcapi/grpcapi.md) or [HTTP](../httpapi/httpapi.md) APIs.
+Hubble keeps events around for 3 days after which they are deleted to save space. To get older data, use the [GRPC](../grpcapi/grpcapi.md) or [HTTP](../httpapi/httpapi.md) APIs.
 
 ## HubEvent
 
@@ -135,7 +135,7 @@ Hubble keeps event around for 3 days after which they are deleted to save space.
 
 | Field           | Type                                        | Label | Description                                      |
 | --------------- | ------------------------------------------- | ----- | ------------------------------------------------ |
-| to              | [bytes](#)                                  |       | The address the fid was registers/transferred to |
+| to              | [bytes](#)                                  |       | The address the fid was registered/transferred to |
 | event_type      | [IdRegisterEventType](#IdRegisterEventType) |       | The type of the id register event                |
 | from            | [bytes](#)                                  |       | The address the transfer originated from         |
 | recover_address | [bytes](#)                                  |       | The recovery address for the fid                 |


### PR DESCRIPTION


Changes:

- "alphabets" -> "letters" (correct term for alphabet characters)
- "which can use it" -> "that can use it" (proper restrictive clause)
- "Hubble emit events" -> "Hubble emits events" (subject-verb agreement)
- "keeps event around" -> "keeps events around" (plural form needed)
- "fid was registers/transferred" -> "fid was registered/transferred" (correct past participle)

These changes improve documentation readability and grammatical correctness while maintaining technical accuracy.