### PR TITLE
Optional Farcaster Manifest in Frames v2 spec

### DIFF
--- a/docs/developers/frames/v2/spec.md
+++ b/docs/developers/frames/v2/spec.md
@@ -90,7 +90,7 @@ type FrameEmbed = {
 
 The manifest file declares the metadata that is applied to the frame application served from this domain. It also defines triggers that indicate which actions it supports from trigger points like casts and the composer.
 
-Frame can provide a JSON manifest file on their domain at the well known URI `/.well-known/farcaster.json` to provide additional provenance and appearance information that can be used by Farcaster clients. 
+Frame should provide a JSON manifest file on their domain at the well known URI `/.well-known/farcaster.json`.
 
 ```ts
 type FarcasterManifest = {

--- a/docs/developers/frames/v2/spec.md
+++ b/docs/developers/frames/v2/spec.md
@@ -22,7 +22,7 @@ Here's an example of a frame using a wallet to complete a transaction:
 
 ## Frame URL Specifications
 
-A URL is considered a valid frame if it includes an embed tag in its HTML `<head>` and a manifest file at a well known location at the root of the domain.
+A URL is considered a valid frame if it includes an embed tag in its HTML `<head>`. An optional manifest file at a well known location at the root of the domain can be provided for additional provenance and appearance information for Farcaster clients.
 
 ### Versioning
 
@@ -90,7 +90,7 @@ type FrameEmbed = {
 
 The manifest file declares the metadata that is applied to the frame application served from this domain. It also defines triggers that indicate which actions it supports from trigger points like casts and the composer.
 
-Frame servers must provide a JSON manifest file on their domain at the well known URI `/.well-known/farcaster.json`.
+Frame can provide a JSON manifest file on their domain at the well known URI `/.well-known/farcaster.json` to provide additional provenance and appearance information that can be used by Farcaster clients. 
 
 ```ts
 type FarcasterManifest = {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the documentation regarding the specifications for valid frame URLs, particularly clarifying the role of the manifest file and its optional nature.

### Detailed summary
- Clarified that a valid frame URL includes an embed tag in its HTML `<head>` and may optionally include a manifest file.
- Changed wording to specify that frames should provide a JSON manifest file at the URI `/.well-known/farcaster.json`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->