### PR TITLE
Update 'getting started' guide

### DIFF
--- a/docs/developers/frames/v2/getting-started.md
+++ b/docs/developers/frames/v2/getting-started.md
@@ -211,7 +211,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
 Note two new things here: since the SDK relies on the browser `window`, we need to define this as a client component with `"use client";` and use a dynamic import to import `WagmiProvider`.
 
-Finally, let's add this providers component to our app layout. Edit `app/layout.tsx`:
+Finally, let's add this providers component to our app layout. If it does not exist already, create a file `app/globals.css` in your project. Then edit `app/layout.tsx`:
 
 ```tsx
 import type { Metadata } from 'next';

--- a/docs/developers/frames/v2/getting-started.md
+++ b/docs/developers/frames/v2/getting-started.md
@@ -20,7 +20,7 @@ The following tutorial is based on the [Frames v2 Demo](https://github.com/farca
 
 ### Setup and dependencies
 
-We'll start with a fresh NextJS app:
+We'll start with a fresh NextJS app. Execute the following command and provide `frames-v2-demo` for the project name and accept the defaults for all prompts _except_ for the prompt to customize the import alias - select `Yes` for that option and set the alias to `~/*`:
 
 ```bash
 $ yarn create next-app
@@ -40,6 +40,12 @@ Next, install frame related dependencies. We'll need the official frame SDK:
 
 ```bash
 $ yarn add @farcaster/frame-sdk
+```
+
+You'll also need [next](https://nextjs.org/) to execute your project:
+
+```bash
+$ yarn add next@latest react@latest react-dom@latest
 ```
 
 We'll also need [Wagmi](https://wagmi.sh/) to handle wallet interactions. Let's install it and its dependencies.
@@ -355,6 +361,7 @@ import sdk, { type FrameContext } from '@farcaster/frame-sdk';
 export default function Demo() {
   const [isSDKLoaded, setIsSDKLoaded] = useState(false);
   const [context, setContext] = useState<FrameContext>();
+  const [isContextOpen, setIsContextOpen] = useState(false);
 
   useEffect(() => {
     const load = async () => {
@@ -366,6 +373,10 @@ export default function Demo() {
       load();
     }
   }, [isSDKLoaded]);
+
+  const toggleContext = useCallback(() => {
+    setIsContextOpen((prev) => !prev);
+  }, []);
 
   if (!isSDKLoaded) {
     return <div>Loading...</div>;


### PR DESCRIPTION
While trying to get started with Farcaster v2 Frames, I encountered a few issues:

* I didn't realize I wasn't supposed to use the default option for the prompt of import aliasing; I added doc to call that out explicitly.
* The `yarn` command doesn't automatically add `next` as an executable; I had to use `yarn add...` to get it added to the project; I've added doc calling that out explicitly.
* One of the example Demo files is missing an import and function declaration, which prevented compilation; I've added that.
* The `app/globals.css` file referenced at one point doesn't actually exist in the project by that point, so I've added a note about needing to ensure that file exists.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the documentation for setting up a NextJS app with `frames-v2`. It includes additional instructions for project setup, dependency installation, and modifications to the app layout and components.

### Detailed summary
- Updated instructions for setting up a NextJS app with `frames-v2-demo`.
- Added command to install `next`, `react`, and `react-dom`.
- Instructed to create `app/globals.css` if it doesn't exist.
- Introduced `isContextOpen` state in the `Demo` component.
- Added `toggleContext` function to manage `isContextOpen` state.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->