### PR TITLE
Add better call to actions for frame devs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -69,7 +69,7 @@ export default defineConfig({
         link: '/learn/',
       },
       {
-        text: 'Developers',
+        text: 'Build apps',
         link: '/developers/',
       },
       {
@@ -80,6 +80,10 @@ export default defineConfig({
       {
         text: 'Reference',
         link: '/reference/',
+      },
+      {
+        text: 'Developer chat',
+        link: 'https://warpcast.com/~/group/X2P7HNc4PHTriCssYHNcmQ',
       },
     ],
     search: {
@@ -153,7 +157,32 @@ export default defineConfig({
         { text: 'Overview', link: '/developers/' },
         { text: 'Resources', link: '/developers/resources' },
         {
-          text: 'Frames',
+          text: 'Frames v2',
+          items: [
+            {
+              text: 'Introduction',
+              link: '/developers/frames/v2/',
+            },
+            {
+              text: 'Getting Started',
+              link: '/developers/frames/v2/getting-started',
+            },
+            {
+              text: 'Notifications & Webhooks',
+              link: '/developers/frames/v2/notifications_webhooks',
+            },
+            {
+              text: 'Specification',
+              link: '/developers/frames/v2/spec',
+            },
+            {
+              text: 'Resources',
+              link: '/developers/frames/v2/resources',
+            },
+          ],
+        },
+        {
+          text: 'Frames v1',
           items: [
             {
               text: 'Introduction',
@@ -178,31 +207,6 @@ export default defineConfig({
             {
               text: 'Resources',
               link: '/developers/frames/resources',
-            },
-          ],
-        },
-        {
-          text: 'Frames v2',
-          items: [
-            {
-              text: 'Introduction',
-              link: '/developers/frames/v2/',
-            },
-            {
-              text: 'Getting Started',
-              link: '/developers/frames/v2/getting-started',
-            },
-            {
-              text: 'Notifications & Webhooks',
-              link: '/developers/frames/v2/notifications_webhooks',
-            },
-            {
-              text: 'Specification',
-              link: '/developers/frames/v2/spec',
-            },
-            {
-              text: 'Resources',
-              link: '/developers/frames/v2/resources',
             },
           ],
         },

--- a/docs/developers/frames/index.md
+++ b/docs/developers/frames/index.md
@@ -4,6 +4,13 @@ title: Frames Introduction
 
 # Frames Introduction
 
+::: info Frames are evolving!
+
+We recently released a new [Frames standard](./v2/index.md) to enable even better in-feed experiences. Frames v1 are stil live, but we recommend Frames v2 for new projects.
+
+Warpcast will continue to support Frames v1 through at least March 2025.
+:::
+
 Frames are a way to build interactive apps that run directly in a Farcaster
 social feed.
 
@@ -20,13 +27,6 @@ Or standalone experiences like polls and games:
 - RSVP to an [Eventcaster](https://warpcast.com/toadyhawk.eth/0xcb4aefe8) event
 - [Yoink](https://warpcast.com/horsefacts.eth/0x70019199) the flag in this simple yet viral social game
 - generate a [Waifu NFT](https://warpcast.com/horsefacts.eth/0xbc7d33ca) based on your Farcaster profile
-
-::: info Frames are evolving!
-
-We're working on a new [Frames standard](./v2/index.md) to enable even better in-feed experiences. You can choose to build on the stable v1 standard, or the experimental v2.
-
-Warpcast will continue to support Frames v1 through at least March 2025.
-:::
 
 ### Farcaster 101
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ hero:
   actions:
     - theme: brand
       text: Build a frame
-      link: /developers/frames/
+      link: /developers/frames/v2/
     - theme: alt
       text: Explore Sign In with Farcaster
       link: /developers/siwf/
@@ -20,9 +20,9 @@ hero:
 
 Learn how to build frames, which are mini-apps that run inside a Farcaster feed.
 
-- [Introduction to Frames](/developers/frames/) - Understand what a frame is and how it works.
-- [Build your first frame](/developers/frames/getting-started) - Make mini-apps that run inside Farcaster.
-- [Specification](/developers/frames/spec) - A formal specification for the Frame standard.
+- [Introduction to Frames](/developers/frames/v2/) - Understand what a frame is and how it works.
+- [Build your first frame](/developers/frames/v2/getting-started) - Make mini-apps that run inside Farcaster.
+- [Specification](/developers/frames/v2/spec) - A formal specification for the Frame standard.
 
 ### Explore Sign In with Farcaster
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the documentation related to `Frames` to reflect the transition to `Frames v2`, including links and references throughout the documentation. It emphasizes the new standard and encourages users to adopt it for new projects.

### Detailed summary
- Updated links from `/developers/frames/` to `/developers/frames/v2/`.
- Added a note about the evolution of `Frames` in `docs/developers/frames/index.md`.
- Changed section titles and links in `docs/.vitepress/config.mts` to reflect `Frames v2`.
- Removed outdated information about `Frames v1`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->