### PR TITLE
Add docs for creator reward history endpoint

### DIFF
--- a/docs/reference/warpcast/api.md
+++ b/docs/reference/warpcast/api.md
@@ -820,3 +820,52 @@ Example:
 ```bash
 curl 'https://api.warpcast.com/v1/blocked-users'
 ```
+
+## Get creator reward winners
+
+`GET /v1/creator-rewards-winner-history`
+
+Warpcast gives out weekly rewards to top creators on the network.
+
+This endpoint provides access to all winners for a given period (week). Paginated, with the list of winners in rank order. Not authenticated.
+
+Query parameters:
+
+- `periodsAgo` (**optional**) - how many periods ago to fetch the results for. 0 or undefined returns results for the most recent period.
+
+Returns:
+
+- `periodStartTimestamp`: Unix time in milliseconds when rewards period began
+- `periodEndTimestamp`: Unix time in milliseconds when rewards period ended
+- `winners`: Paginated list of fid, score, rank and reward amount in rank order
+
+```json
+{
+  "result": {
+    "periodStartTimestamp": 1738080000000,
+    "periodEndTimestamp": 1738684800000,
+    "winners": [
+      {
+        "fid": 1,
+        "score": 10,
+        "rank": 1,
+        "rewardCents": 1000
+      },
+      {
+        "fid": 420,
+        "score": 1,
+        "rank": 2,
+        "rewardCents": 500
+      },
+      ...
+    ]
+  },
+  "next": { "cursor": "..." }
+}
+```
+
+Example:
+
+```bash
+curl 'https://api.warpcast.com/v1/creator-rewards-winner-history'
+```


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new API endpoint for accessing the weekly rewards given to top creators on Warpcast, providing details on winners and their rankings.

### Detailed summary
- Added section for `GET /v1/creator-rewards-winner-history`
- Described the purpose: access to weekly creator reward winners
- Specified query parameter `periodsAgo` as optional
- Outlined the response structure, including `periodStartTimestamp`, `periodEndTimestamp`, and `winners`
- Provided example usage with `curl` command

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->