### PR TITLE
Add docs for new userdata types

### DIFF
--- a/docs/reference/hubble/datatypes/messages.md
+++ b/docs/reference/hubble/datatypes/messages.md
@@ -105,6 +105,12 @@ Type of UserData message
 | USER_DATA_TYPE_BIO      | 3      | Bio for the user                      |
 | USER_DATA_TYPE_URL      | 5      | URL of the user                       |
 | USER_DATA_TYPE_USERNAME | 6      | Preferred Farcaster Name for the user |
+| USER_DATA_TYPE_LOCATION | 7      | Location for the user                 |
+| USER_DATA_TYPE_TWITTER  | 8      | Twitter username for the user         |
+| USER_DATA_TYPE_GITHUB   | 9      | GitHub username for the user          |
+
+See [FIP-196](https://github.com/farcasterxyz/protocol/discussions/196) for more information on Location.
+See [FIP-19](https://github.com/farcasterxyz/protocol/discussions/199) for more information on Twitter/X and Github usernames.
 
 ## 3. Cast
 

--- a/docs/reference/hubble/httpapi/userdata.md
+++ b/docs/reference/hubble/httpapi/userdata.md
@@ -2,13 +2,19 @@
 
 The UserData API will accept the following values for the `user_data_type` field.
 
-| String                  | Numerical value | Description                  |
-| ----------------------- | --------------- | ---------------------------- |
-| USER_DATA_TYPE_PFP      | 1               | Profile Picture for the user |
-| USER_DATA_TYPE_DISPLAY  | 2               | Display Name for the user    |
-| USER_DATA_TYPE_BIO      | 3               | Bio for the user             |
-| USER_DATA_TYPE_URL      | 5               | URL of the user              |
-| USER_DATA_TYPE_USERNAME | 6               | Preferred Name for the user  |
+| String                  | Numerical value | Description                   |
+| ----------------------- | --------------- | ----------------------------- |
+| USER_DATA_TYPE_PFP      | 1               | Profile Picture for the user  |
+| USER_DATA_TYPE_DISPLAY  | 2               | Display Name for the user     |
+| USER_DATA_TYPE_BIO      | 3               | Bio for the user              |
+| USER_DATA_TYPE_URL      | 5               | URL of the user               |
+| USER_DATA_TYPE_USERNAME | 6               | Preferred Name for the user   |
+| USER_DATA_TYPE_LOCATION | 7               | Location for the user         |
+| USER_DATA_TYPE_TWITTER  | 8               | Twitter username for the user |
+| USER_DATA_TYPE_GITHUB   | 9               | GitHub username for the user  |
+
+See [FIP-196](https://github.com/farcasterxyz/protocol/discussions/196) for more information on Location.
+See [FIP-19](https://github.com/farcasterxyz/protocol/discussions/199) for more information on Twitter/X and Github usernames.
 
 ## userDataByFid
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the documentation for the UserData API by adding new user data types, including `USER_DATA_TYPE_LOCATION`, `USER_DATA_TYPE_TWITTER`, and `USER_DATA_TYPE_GITHUB`, along with their descriptions. It also includes references to relevant FIPs for further information.

### Detailed summary
- Added `USER_DATA_TYPE_LOCATION` with description "Location for the user".
- Added `USER_DATA_TYPE_TWITTER` with description "Twitter username for the user".
- Added `USER_DATA_TYPE_GITHUB` with description "GitHub username for the user".
- Included references to [FIP-196](https://github.com/farcasterxyz/protocol/discussions/196) and [FIP-19](https://github.com/farcasterxyz/protocol/discussions/199) for additional context.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->