### PR TITLE
minor docs updates

### DIFF
--- a/docs/developers/frames/v2/getting-started.md
+++ b/docs/developers/frames/v2/getting-started.md
@@ -655,8 +655,6 @@ export default function Demo() {
 }
 ```
 
-<img src="https://raw.githubusercontent.com/farcasterxyz/frames-v2-demo/refs/heads/main/docs/img/10_wallet.png" width="200" alt="Wallet" />
-
 If your wallet is connected to Warpcast, you should see its address. In case it's not, let's add a connect/disconnect button. Note that we'll need to import our Wagmi config to `connect`:
 
 ```tsx

--- a/docs/developers/frames/v2/getting-started.md
+++ b/docs/developers/frames/v2/getting-started.md
@@ -286,7 +286,7 @@ $ ngrok http http://localhost:3000
 ```
 
 ::: info Tunneling gotchas
-Some tunneling tools, like the ngrok free tier, insert an click-through interstitial between your dev server and the tunnel endpoint. Use a paid ngrok account or a different tool, like Tailscale funnel.
+Some tunneling tools, like the ngrok free tier, insert a click-through interstitial between your dev server and the tunnel endpoint. Use a paid ngrok account or a different tool, like Tailscale funnel.
 :::
 
 Now open the Frame Playground on Warpcast mobile, by visiting [https://warpcast.com/~/developers/frame](https://warpcast.com/~/developers/frames).

--- a/docs/developers/frames/v2/index.md
+++ b/docs/developers/frames/v2/index.md
@@ -1,6 +1,6 @@
 # Frames v2 Introduction
 
-[Frames](../index.md) launched in January 2024 as a a way to build interactive apps that run directly in a Farcaster social feed. They enabled developers to identify users, connect wallets, and take limited actions on and offchain.
+[Frames](../index.md) launched in January 2024 as a way to build interactive apps that run directly in a Farcaster social feed. They enabled developers to identify users, connect wallets, and take limited actions on and offchain.
 
 Although we saw many apps built, they were held back by several limitations:
 

--- a/docs/developers/frames/v2/notifications_webhooks.md
+++ b/docs/developers/frames/v2/notifications_webhooks.md
@@ -137,7 +137,7 @@ export type SendNotificationResponse = z.infer<
 
 The request is a JSON consisting of:
 
-- `notificationId`: a string (max size 128) that servers as an idempotency key and will be passed back to the frame via context. A Farcaster client should deliver only one notification per user per `notificationId`, even if called multiple times.
+- `notificationId`: a string (max size 128) that serves as an idempotency key and will be passed back to the frame via context. A Farcaster client should deliver only one notification per user per `notificationId`, even if called multiple times.
 - `title`: title of the notification, max 32 characters
 - `body`: body of the notification, max 128 characters
 - `targetUrl`: the target frame URL to open when a user clicks the notification. It must match the domain for which the notification token was issued. Max 256 characters.
@@ -172,7 +172,7 @@ export type FrameLocationNotificationContext = {
 
 ## Listen for webhooks to get updates
 
-Farcast clients will POST events to your `webhookUrl` informing you when a user:
+Farcaster clients will POST events to your `webhookUrl` informing you when a user:
 
 - Adds the frame to the client (`frame_added`)
 - Removes the frame from the client which disables notifications (`frame_removed`)
@@ -242,7 +242,7 @@ Webhook payload:
 
 ### `notifications_disabled`: user disabled notifications
 
-Sent when a disables frame notifications from e.g. a settings panel in the client app. Any notification tokens for that fid and client app (based on signer requester) should be considered invalid:
+Sent when a user disables frame notifications from e.g. a settings panel in the client app. Any notification tokens for that fid and client app (based on signer requester) should be considered invalid:
 
 Webhook payload:
 

--- a/docs/developers/frames/v2/spec.md
+++ b/docs/developers/frames/v2/spec.md
@@ -891,7 +891,7 @@ The frame server is given an authentication token and a URL which they can use t
 
 The frame server calls the `notificationUrl` with:
 
-- `notificationId`: a string (max size 128) that servers as an idempotency key and will be passed back to the frame via context. A Farcaster client should deliver only one notification per user per `notificationId`, even if called multiple times.
+- `notificationId`: a string (max size 128) that serves as an idempotency key and will be passed back to the frame via context. A Farcaster client should deliver only one notification per user per `notificationId`, even if called multiple times.
 - `title`: title of the notification, max length of 32 characters
 - `body`: body of the notification
 - `targetUrl`: the target frame URL to open when a user clicks the notification. It must match the domain for which the notification token was issued.

--- a/docs/developers/frames/v2/spec.md
+++ b/docs/developers/frames/v2/spec.md
@@ -10,7 +10,7 @@ It can be embedded in feeds in a compact form which includes an image and a butt
 
 <img width="1330" alt="Screenshot 2024-11-20 at 7 28 48 PM" src="https://github.com/user-attachments/assets/9d076056-f8df-46dd-8630-e8caf5b3def4">
 
-Frames will have access to :
+Frames will have access to:
 
 1. Context: information about the user's Farcaster account and where the frame was called from
 2. Actions: APIs to request the parent app to do certain things on the frame's behalf
@@ -836,7 +836,7 @@ type EventNotificationsEnabledPayload = {
 
 Farcaster clients emit events to your frame, while it is open, to let you know of actions the user takes.
 
-To listen to events, you have to use `sdk.on` to register callbacks ([see full example](https://github.com/farcasterxyz/frames-v2-demo/blob/20d454f5f6b1e4f30a6a49295cbd29ca7f30d44a/src/components/Demo.ts#L92-L124)).
+To listen to events, you have to use `sdk.on` to register callbacks ([see full example](https://github.com/farcasterxyz/frames-v2-demo/blob/20d454f5f6b1e4f30a6a49295cbd29ca7f30d44a/src/components/Demo.tsx#L92-L124)).
 
 ```ts
 sdk.on('frameAdded', ({ notificationDetails }) => {
@@ -1016,12 +1016,12 @@ type SetPrimaryButton = (options: {
 
 An app frame should subscribe to the `primaryButtonClicked` event to respond to interactions.
 
-### primaryButtonClick (Event)
+### primaryButtonClicked (Event)
 
 Emitted when user clicks the Primary Button.
 
 ```ts
-> Farcaster.events.on("primaryButtonClick", () => {
+> Farcaster.events.on("primaryButtonClicked", () => {
     console.log("clicked!") }
 );
 ```

--- a/docs/developers/siwf/index.md
+++ b/docs/developers/siwf/index.md
@@ -4,7 +4,7 @@ title: Sign In with Farcaster
 
 # Introduction
 
-Sign In with Farcaster (SIWF) is way for users to sign into any app using their
+Sign In with Farcaster (SIWF) is a way for users to sign into any app using their
 Farcaster identity.
 
 When a user signs into your application with Farcaster you'll be able to use
@@ -22,6 +22,6 @@ a streamlined onboarding experience and social-powered features.
 
 ## Next Steps
 
-- integrate SIWF to your app today with [AuthKit](/auth-kit/).
-- read about the underlying standard in [FIP-11: Sign In With
-  Farcaster](https://github.com/farcasterxyz/protocol/discussions/110)
+- Integrate SIWF to your app today with [AuthKit](/auth-kit/).
+- Read about the underlying standard in [FIP-11: Sign In With
+  Farcaster](https://github.com/farcasterxyz/protocol/discussions/110).


### PR DESCRIPTION
- fix broken link on "see full example" on the frames spec page
- update `primaryButtonClick` to `primaryButtonClicked`
- remove broken wallet image
- fix minor format

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the documentation for the `Frames` and `Sign In with Farcaster (SIWF)` features, correcting grammatical errors and enhancing clarity throughout various markdown files.

### Detailed summary
- Corrected "a way" to "a way" in `docs/developers/siwf/index.md`.
- Updated bullet points to start with capital letters in `docs/developers/siwf/index.md`.
- Fixed "an click-through" to "a click-through" in `docs/developers/frames/v2/getting-started.md`.
- Changed "servers" to "serves" in multiple instances in `docs/developers/frames/v2/notifications_webhooks.md` and `docs/developers/frames/v2/spec.md`.
- Updated event name from "primaryButtonClick" to "primaryButtonClicked" in `docs/developers/frames/v2/spec.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->