### PR TITLE
Add blockaid verification warning

### DIFF
--- a/docs/developers/frames/v2/getting-started.md
+++ b/docs/developers/frames/v2/getting-started.md
@@ -605,6 +605,9 @@ When you tap this, the frame should close.
 
 ### Wallet interactions
 
+> [!WARNING]
+> If you are launching a new smart contract, your users may see a warning on Warpcast. To prevent it, warm it up with some transactions and verify it with [Blockaid](https://report.blockaid.io/verifiedProject).
+
 Finally, let's interact with the user's connected wallet. To do so, we can use the wallet connector and Wagmi hooks we set up earlier. To start, let's read the user's connected wallet address, using `useAccount`:
 
 ```tsx


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a warning note to the `getting-started.md` documentation regarding potential user warnings on Warpcast when launching new smart contracts. It advises warming up the contract with transactions and verifying it with Blockaid.

### Detailed summary
- Added a warning note about user warnings on Warpcast for new smart contracts.
- Suggested warming up the contract with transactions to prevent warnings.
- Provided a link to Blockaid for contract verification.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->