### PR TITLE
Add Frames.js Local Debugger to Frames v2 Docs

### DIFF
--- a/docs/developers/frames/v2/resources.md
+++ b/docs/developers/frames/v2/resources.md
@@ -25,6 +25,7 @@ title: Frames v2 Resources
 
 - [Frame Playground](https://warpcast.com/~/developers/frames) - Warpcast Frame developer tools
 - [Frame SDK](https://github.com/farcasterxyz/frames/) - Frame SDK JavaScript library
+- [Frames.js Local Debugger](https://framesjs.org/guides/debugger) - Frame Local Debugger
 
 #### Learning
 


### PR DESCRIPTION
Re: https://warpcast.com/deodad/0x1a2cb659

@deodad 
<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `resources.md` documentation by replacing two links related to `Frame Playground` and `Frame SDK` with a new link to the `Frames.js Local Debugger`.

### Detailed summary
- Removed the link to `Frame Playground`.
- Removed the link to `Frame SDK`.
- Added a link to `Frames.js Local Debugger`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->