### PR TITLE
Add docs for GET /fc/starter-pack-members

### DIFF
--- a/docs/reference/warpcast/api.md
+++ b/docs/reference/warpcast/api.md
@@ -1051,3 +1051,43 @@ Example:
 ```bash
 curl 'https://api.warpcast.com/v1/creator-rewards-winner-history'
 ```
+
+## Get Starter Pack Members
+
+`GET /fc/starter-pack-members`
+
+Starter pack members. Ordered by the time when they were added to the pack, descending. Paginated. Not authenticated.
+
+Query parameters:
+
+- `id` - starter pack id found as a part of the public Warpcast pack URL or in the non-authed public API of starter pack metadata.
+
+Returns: a `members` array:
+
+- `fid` - account Farcaster id
+- `memberAt` - time when member was added to the starter pack, in milliseconds
+
+```json
+{
+  "result": {
+    "members": [
+      {
+        "fid": 3,
+        "memberAt": 1740172669691
+      },
+      {
+        "fid": 296646,
+        "memberAt": 1740172669691
+      },
+      ...
+    ]
+  },
+  "next": { "cursor": "..." }
+}
+```
+
+Example:
+
+```bash
+curl 'https://api.warpcast.com/fc/starter-pack-members?id=Underrated-CT-1y7n9b'
+```


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new API endpoint for retrieving members of a starter pack in the Warpcast application, including details on the response format and example usage.

### Detailed summary
- Added documentation for a new endpoint: `GET /fc/starter-pack-members`.
- Described the purpose: to fetch members of a starter pack, ordered by addition time.
- Listed query parameter: `id` for the starter pack.
- Specified the response structure, including `members` array and example JSON response.
- Provided a usage example using `curl`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->