### PR TITLE
 Fix typos in signer-requests.md and signers.md

### DIFF
--- a/docs/reference/warpcast/signer-requests.md
+++ b/docs/reference/warpcast/signer-requests.md
@@ -60,7 +60,7 @@ const key = '0x' + Buffer.from(publicKeyBytes).toString('hex');
 /*** Generating a Signed Key Request signature ***/
 
 const appFid = process.env.APP_FID;
-const account = mnemonicToAccount(process.env.APP_MNENOMIC);
+const account = mnemonicToAccount(process.env.APP_MNEMONIC);
 
 const deadline = Math.floor(Date.now() / 1000) + 86400; // signature is valid for 1 day
 const signature = await account.signTypedData({
@@ -180,7 +180,7 @@ poll(token);
 
 When the user approves the request in Warpcast, an onchain transaction will be
 made that grants write permissions to that signer. Once that completes your app
-should indicate success and can being writing messages using the newly added key.
+should indicate success and can begin writing messages using the newly added key.
 
 ### Reference implementation
 

--- a/docs/reference/warpcast/signers.md
+++ b/docs/reference/warpcast/signers.md
@@ -17,7 +17,7 @@ them with the option to Connect with Warpcast.
 
 Your app should generate and securely store an Ed25519 associated with this
 user. In the next steps, you will prompt the user to approve this keypair to
-signer messages on their behalf.
+sign messages on their behalf.
 
 Since this keypair can write to the protocol on behalf of the user it's
 important that:
@@ -61,7 +61,7 @@ const key = '0x' + Buffer.from(publicKeyBytes).toString('hex');
 /*** Generating a Signed Key Request signature ***/
 
 const appFid = process.env.APP_FID;
-const account = mnemonicToAccount(process.env.APP_MNENOMIC);
+const account = mnemonicToAccount(process.env.APP_MNEMONIC);
 
 const deadline = Math.floor(Date.now() / 1000) + 86400; // signature is valid for 1 day
 const signature = await account.signTypedData({


### PR DESCRIPTION
This PR fixes  typos across two documentation files:

## Changes

### `signer-requests.md`
- Fixed typo: `APP_MNENOMIC` → `APP_MNEMONIC`
- Grammar: "can being writing" → "can begin writing"

### `signers.md`
- Fixed typo: `APP_MNENOMIC` → `APP_MNEMONIC`
- Grammar: "signer messages" → "sign messages"

## Context
- Documentation-only changes (no code logic affected)
- Typos were causing confusion in code snippets
- Aligns with Ethereum/Hubble terminology

## Checklist
- [x] Verified against project glossary
- [x] Changes limited to typos/grammar
