### PR TITLE
Made initial changes

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -489,7 +489,10 @@ export default defineConfig({
         },
         {
           text: 'Mini Apps',
-          items: [{ text: 'Specification', link: 'https://miniapps.farcaster.xyz/docs/specification', target: '_self' }],
+          items: [
+            { text: 'Specification', link: 'https://miniapps.farcaster.xyz/docs/specification', target: '_self' },
+            { text: 'Rename from Frames', link: '/reference/frames-redirect'}
+          ],
         },
         {
           text: 'Actions',

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -196,7 +196,7 @@ export default defineConfig({
               target: '_self',
             },
             {
-              text: 'Rename from Frames',
+              text: 'Rename from Frames v2',
               link: '/reference/frames-redirect',
             }
           ],
@@ -495,7 +495,7 @@ export default defineConfig({
           text: 'Mini Apps',
           items: [
             { text: 'Specification', link: 'https://miniapps.farcaster.xyz/docs/specification', target: '_self' },
-            { text: 'Rename from Frames', link: '/reference/frames-redirect'}
+            { text: 'Rename from Frames v2', link: '/reference/frames-redirect'}
           ],
         },
         {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -139,6 +139,10 @@ export default defineConfig({
               link: '/learn/what-is-farcaster/apps',
               target: '_self',
             },
+            {
+              text: 'Rename from Frames',
+              link: '/reference/frames-redirect',
+            }
           ],
         },
         {
@@ -195,6 +199,10 @@ export default defineConfig({
               link: 'https://miniapps.farcaster.xyz/docs/specification',
               target: '_self',
             },
+            {
+              text: 'Rename from Frames',
+              link: '/reference/frames-redirect',
+            }
           ],
         },
         {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -139,10 +139,6 @@ export default defineConfig({
               link: '/learn/what-is-farcaster/apps',
               target: '_self',
             },
-            {
-              text: 'Rename from Frames',
-              link: '/reference/frames-redirect',
-            }
           ],
         },
         {

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -4,7 +4,7 @@ Ask questions and hang out with other Farcaster developers in the [/fc-devs](htt
 
 ## Create mini apps
 
-Learn how to build mini apps that run inside a Farcaster feed.
+Learn how to build mini apps (previously called Frames) that run inside a Farcaster feed.
 
 <!-- prettier-ignore -->
 - [Introduction](https://miniapps.farcaster.xyz/){target="_self"}- understand what a mini app is and how it works

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,9 +17,9 @@ hero:
       link: /learn/
 ---
 
-### Build a mini app
+### Build a Mini App
 
-Learn how to build mini apps (previously known as Frames) that run inside a Farcaster feed.
+Learn how to build Mini Apps (previously known as Frames v2) that run inside a Farcaster feed.
 
 <!-- prettier-ignore -->
 - [Introduction to Mini Apps](https://miniapps.farcaster.xyz/){target="_self"}- Understand what a mini app is and how it works.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ hero:
 
 ### Build a mini app
 
-Learn how to build mini apps that run inside a Farcaster feed.
+Learn how to build mini apps (previously known as Frames) that run inside a Farcaster feed.
 
 <!-- prettier-ignore -->
 - [Introduction to Mini Apps](https://miniapps.farcaster.xyz/){target="_self"}- Understand what a mini app is and how it works.

--- a/docs/reference/frames-redirect.md
+++ b/docs/reference/frames-redirect.md
@@ -1,0 +1,11 @@
+---
+title: Frames have been rebranded to Mini Apps
+---
+
+# Frames have been rebranded to Mini Apps
+
+As of early 2025, Frames have been rebranded to Mini Apps to better reflect their evolving capabilities and scope. All Frames documentation and resources have been migrated to the [Mini Apps](https://miniapps.farcaster.xyz/){target="\_self"} ecosystem.
+
+Frames v1 have been deprecated and will be supported only until the end of March 2025. We strongly recommend using Mini Apps for all new projects.
+
+[Go to Mini Apps Documentation →](https://miniapps.farcaster.xyz/){target="\_self"}

--- a/docs/reference/frames-redirect.md
+++ b/docs/reference/frames-redirect.md
@@ -1,8 +1,8 @@
 ---
-title: Frames have been rebranded to Mini Apps
+title: Frames v2 have been rebranded to Mini Apps
 ---
 
-# Frames have been rebranded to Mini Apps
+# Frames v2 have been rebranded to Mini Apps
 
 <!-- prettier-ignore -->
 As of early 2025, Frames v2 have been rebranded to Mini Apps. All Frames documentation and resources have been migrated to the [Mini Apps](https://miniapps.farcaster.xyz/){target="_self"} ecosystem.

--- a/docs/reference/frames-redirect.md
+++ b/docs/reference/frames-redirect.md
@@ -4,8 +4,10 @@ title: Frames have been rebranded to Mini Apps
 
 # Frames have been rebranded to Mini Apps
 
-As of early 2025, Frames have been rebranded to Mini Apps to better reflect their evolving capabilities and scope. All Frames documentation and resources have been migrated to the [Mini Apps](https://miniapps.farcaster.xyz/){target="\_self"} ecosystem.
+<!-- prettier-ignore -->
+As of early 2025, Frames have been rebranded to Mini Apps to better reflect their evolving capabilities and scope. All Frames documentation and resources have been migrated to the [Mini Apps](https://miniapps.farcaster.xyz/){target="_self"} ecosystem.
 
 Frames v1 have been deprecated and will be supported only until the end of March 2025. We strongly recommend using Mini Apps for all new projects.
 
-[Go to Mini Apps Documentation →](https://miniapps.farcaster.xyz/){target="\_self"}
+<!-- prettier-ignore -->
+[Go to Mini Apps Documentation →](https://miniapps.farcaster.xyz/){target="_self"}

--- a/docs/reference/frames-redirect.md
+++ b/docs/reference/frames-redirect.md
@@ -5,9 +5,9 @@ title: Frames have been rebranded to Mini Apps
 # Frames have been rebranded to Mini Apps
 
 <!-- prettier-ignore -->
-As of early 2025, Frames have been rebranded to Mini Apps to better reflect their evolving capabilities and scope. All Frames documentation and resources have been migrated to the [Mini Apps](https://miniapps.farcaster.xyz/){target="_self"} ecosystem.
+As of early 2025, Frames v2 have been rebranded to Mini Apps. All Frames documentation and resources have been migrated to the [Mini Apps](https://miniapps.farcaster.xyz/){target="_self"} ecosystem.
 
-Frames v1 have been deprecated and will be supported only until the end of March 2025. We strongly recommend using Mini Apps for all new projects.
+Frames v2 have been deprecated and will be supported only until the end of March 2025. We strongly recommend using Mini Apps for all new projects.
 
 <!-- prettier-ignore -->
 [Go to Mini Apps Documentation →](https://miniapps.farcaster.xyz/){target="_self"}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on rebranding "Frames" to "Mini Apps" across the documentation and adding a redirect for users. It clarifies the transition and encourages users to adopt the new terminology and resources.

### Detailed summary
- Updated text to refer to "Mini Apps" instead of "Frames" in `docs/developers/index.md` and `docs/index.md`.
- Added a new section in `docs/.vitepress/config.mts` for a redirect link to the `frames-redirect.md`.
- Created `docs/reference/frames-redirect.md` to inform users about the rebranding and deprecation of Frames v2.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->