### PR TITLE
setup frames v2 -> mini apps redirects

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -15,6 +15,31 @@
       "source": "/reference/frames/spec",
       "destination": "/developers/frames/spec",
       "permanent": true
+    },
+    {
+      "source": "/auth-kit/introduction",
+      "destination": "/auth-kit/",
+      "permanent": true
+    },
+    {
+      "source": "/docs/developers/frames",
+      "destination": "https://miniapps.farcaster.xyz",
+      "permanent": true
+    },
+    {
+      "source": "/developers/frames/v2/getting-started",
+      "destination": "https://miniapps.farcaster.xyz/docs/getting-started",
+      "permanent": true
+    },
+    {
+      "source": "/developers/frames/v2/notifications_webhooks",
+      "destination": "https://miniapps.farcaster.xyz/docs/guides/notifications",
+      "permanent": true
+    },
+    {
+      "source": "/developers/frames/v2/spec",
+      "destination": "https://miniapps.farcaster.xyz/docs/specification",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding new redirect rules to the `vercel.json` configuration file for various routes, directing users to specific destinations, including external URLs for documentation and introduction pages.

### Detailed summary
- Added a redirect from `/auth-kit/introduction` to `/auth-kit/`
- Redirect `/docs/developers/frames` to `https://miniapps.farcaster.xyz`
- Redirect `/developers/frames/v2/getting-started` to `https://miniapps.farcaster.xyz/docs/getting-started`
- Redirect `/developers/frames/v2/notifications_webhooks` to `https://miniapps.farcaster.xyz/docs/guides/notifications`
- Redirect `/developers/frames/v2/spec` to `https://miniapps.farcaster.xyz/docs/specification`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->