### PR TITLE
setup frames v2 -> mini apps redirects

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,11 @@
       "permanent": true
     },
     {
+      "source": "/docs/developers/frames/",
+      "destination": "https://miniapps.farcaster.xyz",
+      "permanent": true
+    },
+    {
       "source": "/developers/frames/v2/getting-started",
       "destination": "https://miniapps.farcaster.xyz/docs/getting-started",
       "permanent": true

--- a/vercel.json
+++ b/vercel.json
@@ -15,6 +15,31 @@
       "source": "/reference/frames/spec",
       "destination": "/developers/frames/spec",
       "permanent": true
+    },
+    {
+      "source": "/auth-kit/introduction",
+      "destination": "/auth-kit/",
+      "permanent": true
+    },
+    {
+      "source": "/docs/developers/frames",
+      "destination": "https://miniapps.farcaster.xyz",
+      "permanent": true
+    },
+    {
+      "source": "/developers/frames/v2/getting-started",
+      "destination": "https://miniapps.farcaster.xyz/docs/getting-started",
+      "permanent": true
+    },
+    {
+      "source": "/developers/frames/v2/notifications_webhooks",
+      "destination": "https://miniapps.farcaster.xyz/docs/guides/notifications",
+      "permanent": true
+    },
+    {
+      "source": "/developers/frames/v2/spec",
+      "destination": "https://miniapps.farcaster.xyz/docs/specification",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding new redirect rules in the `vercel.json` configuration file to manage the routing of various paths to their corresponding destinations, enhancing the navigation structure for users.

### Detailed summary
- Added redirect from `/auth-kit/introduction` to `/auth-kit/`.
- Redirected `/docs/developers/frames` and `/docs/developers/frames/` to `https://miniapps.farcaster.xyz`.
- Redirected `/developers/frames/v2/getting-started` to `https://miniapps.farcaster.xyz/docs/getting-started`.
- Redirected `/developers/frames/v2/notifications_webhooks` to `https://miniapps.farcaster.xyz/docs/guides/notifications`.
- Redirected `/developers/frames/v2/spec` to `https://miniapps.farcaster.xyz/docs/specification`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->