### PR TITLE
add redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -90,6 +90,11 @@
       "source": "/developers/frames/v2/spec",
       "destination": "https://miniapps.farcaster.xyz/docs/specification",
       "permanent": true
+    },
+    {
+      "source": "/reference/frames/spec",
+      "destination": "https://miniapps.farcaster.xyz/docs/specification",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new route to the `vercel.json` configuration for redirecting requests from `/reference/frames/spec` to the `https://miniapps.farcaster.xyz/docs/specification` URL.

### Detailed summary
- Added a new route with `source`: `/reference/frames/spec`
- Set `destination` to `https://miniapps.farcaster.xyz/docs/specification`
- Marked the route as `permanent`: true

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->