### PR TITLE
add call for composecast on cast intent urls

### DIFF
--- a/docs/reference/warpcast/cast-composer-intents.md
+++ b/docs/reference/warpcast/cast-composer-intents.md
@@ -8,6 +8,10 @@ title: Warpcast Intents URLs
 
 Warpcast intents enable builders to direct authenticated users to a pre-filled cast composer.
 
+> [!IMPORTANT]
+> If you're building a Mini App and want to prompt the user to compose a cast, use the [composeCast action](https://miniapps.farcaster.xyz/docs/sdk/actions/compose-cast)
+> from the Mini App SDK.
+
 #### Compose with cast text
 
 ```


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the documentation for `Warpcast` intents, specifically highlighting how builders can direct users to compose a cast. It includes important information for Mini App developers regarding the `composeCast` action.

### Detailed summary
- Added an important note for Mini App builders about using the `composeCast` action.
- Provided a link to the Mini App SDK documentation for `composeCast`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->