### PR TITLE
Drop remaining references to Warpcast and api.warpcast.com

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -83,7 +83,7 @@ export default defineConfig({
       },
       {
         text: 'Developer chat',
-        link: 'https://warpcast.com/~/group/X2P7HNc4PHTriCssYHNcmQ',
+        link: 'https://farcaster.xyz/~/group/X2P7HNc4PHTriCssYHNcmQ',
       },
     ],
     search: {
@@ -506,18 +506,18 @@ export default defineConfig({
         {
           text: 'Warpcast',
           items: [
-            { text: 'APIs', link: '/reference/warpcast/api' },
+            { text: 'APIs', link: '/reference/client/api' },
             {
               text: 'Signer Requests',
-              link: '/reference/warpcast/signer-requests',
+              link: '/reference/client/signer-requests',
             },
             {
               text: 'Intent URLs',
-              link: '/reference/warpcast/cast-composer-intents',
+              link: '/reference/client/cast-composer-intents',
             },
-            { text: 'Direct Casts', link: '/reference/warpcast/direct-casts' },
-            { text: 'Embeds', link: '/reference/warpcast/embeds' },
-            { text: 'Videos', link: '/reference/warpcast/videos' },
+            { text: 'Direct Casts', link: '/reference/client/direct-casts' },
+            { text: 'Embeds', link: '/reference/client/embeds' },
+            { text: 'Videos', link: '/reference/client/videos' },
           ],
         },
         {
@@ -711,7 +711,7 @@ export default defineConfig({
         icon: {
           svg: '<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M4.11841 1H19.5982V4.09052H24L23.0775 7.18179H22.2964V19.6873C22.6881 19.6873 23.0061 20.0012 23.0061 20.3892V21.2321H23.1481C23.5406 21.2321 23.8587 21.5468 23.8587 21.9348V22.7778H15.9053V21.9348C15.9053 21.5468 16.2233 21.2321 16.6157 21.2321H16.7578V20.3892C16.7578 20.0519 16.9984 19.7702 17.3187 19.7024L17.3037 12.8021C17.0526 10.0451 14.7107 7.88443 11.8583 7.88443C9.00593 7.88443 6.66403 10.0451 6.41293 12.8021L6.3979 19.6963C6.7768 19.7521 7.24293 20.0412 7.24293 20.3892V21.2321H7.38502C7.77671 21.2321 8.09473 21.5468 8.09473 21.9348V22.7778H0.142092V21.9348C0.142092 21.5468 0.460107 21.2321 0.8518 21.2321H0.993892V20.3892C0.993892 20.0012 1.31191 19.6873 1.70436 19.6873V7.18179H0.923221L0 4.09052H4.11841V1Z" /></svg>',
         },
-        link: 'https://warpcast.com/~/channel/fc-devs',
+        link: 'https://farcaster.xyz/~/channel/fc-devs',
       },
       { icon: 'github', link: 'https://github.com/farcasterxyz/protocol' },
       { icon: 'twitter', link: 'https://x.com/farcaster_xyz' },

--- a/docs/auth-kit/client/app/create-channel.md
+++ b/docs/auth-kit/client/app/create-channel.md
@@ -38,11 +38,11 @@ const channel = await appClient.createChannel({
 }
 ```
 
-| Parameter           | Description                                                                        |
-| ------------------- | ---------------------------------------------------------------------------------- |
-| `response`          | HTTP response from the Connect relay server.                                       |
-| `data.channelToken` | Connect relay channel token.                                                       |
-| `data.url`          | Sign in With Farcaster URL to present to the user. Links to Warpcast client in v1. |
-| `data.nonce`        | Random nonce included in the Sign in With Farcaster message.                       |
-| `isError`           | True when an error has occurred.                                                   |
-| `error`             | `Error` instance.                                                                  |
+| Parameter           | Description                                                                             |
+| ------------------- | --------------------------------------------------------------------------------------- |
+| `response`          | HTTP response from the Connect relay server.                                            |
+| `data.channelToken` | Connect relay channel token.                                                            |
+| `data.url`          | Sign in With Farcaster URL to present to the user. Links to the Farcaster client in v1. |
+| `data.nonce`        | Random nonce included in the Sign in With Farcaster message.                            |
+| `isError`           | True when an error has occurred.                                                        |
+| `error`             | `Error` instance.                                                                       |

--- a/docs/auth-kit/client/app/status.md
+++ b/docs/auth-kit/client/app/status.md
@@ -72,7 +72,7 @@ const status = await appClient.status({
 | `data.nonce`              | Random nonce used in the SIWE message. If you don't provide a custom nonce as an argument to the hook, you should read this value. |
 | `data.url`                | URL of the application.                                                                                                            |
 | `data.message`            | The generated SIWE message.                                                                                                        |
-| `data.signature`          | Hex signature produced by the user's Warpcast wallet.                                                                              |
+| `data.signature`          | Hex signature produced by the user's Farcaster client app wallet.                                                                  |
 | `data.authMethod`         | Auth method used to sign the message. Either `"custody"` or `"authAddress"`.                                                       |
 | `data.fid`                | User's Farcaster ID.                                                                                                               |
 | `data.username`           | User's Farcaster username.                                                                                                         |

--- a/docs/auth-kit/client/wallet/authenticate.md
+++ b/docs/auth-kit/client/wallet/authenticate.md
@@ -17,18 +17,18 @@ const params = await walletClient.authenticate({
 
 ## Parameters
 
-| Parameter      | Type     | Description                                                                               | Required |
-| -------------- | -------- | ----------------------------------------------------------------------------------------- | -------- |
-| `authKey`      | `string` | Farcaster Auth API key. Farcaster Auth v1 restricts calls to `/authenticate` to Warpcast. | Yes      |
-| `channelToken` | `string` | Farcaster Auth channel token.                                                             | Yes      |
-| `message`      | `string` | The Sign in With Farcaster message produced by your wallet app and signed by the user.    | Yes      |
-| `signature`    | `Hex`    | SIWE signature created by the wallet user's account.                                      | Yes      |
-| `authMethod`   | `string` | Method used to sign the SIWF message. Either `"custody"` or `"authAddress"`.              | Yes      |
-| `fid`          | `number` | Wallet user's fid.                                                                        | Yes      |
-| `username`     | `string` | Wallet user's Farcaster username.                                                         | Yes      |
-| `bio`          | `string` | Wallet user's bio.                                                                        | Yes      |
-| `displayName`  | `string` | Wallet user's display name.                                                               | Yes      |
-| `pfpUrl`       | `string` | Wallet user's profile photo URL.                                                          | Yes      |
+| Parameter      | Type     | Description                                                                                                    | Required |
+| -------------- | -------- | -------------------------------------------------------------------------------------------------------------- | -------- |
+| `authKey`      | `string` | Farcaster Auth API key. Farcaster Auth v1 restricts calls to `/authenticate` to the official Farcaster client. | Yes      |
+| `channelToken` | `string` | Farcaster Auth channel token.                                                                                  | Yes      |
+| `message`      | `string` | The Sign in With Farcaster message produced by your wallet app and signed by the user.                         | Yes      |
+| `signature`    | `Hex`    | SIWE signature created by the wallet user's account.                                                           | Yes      |
+| `authMethod`   | `string` | Method used to sign the SIWF message. Either `"custody"` or `"authAddress"`.                                   | Yes      |
+| `fid`          | `number` | Wallet user's fid.                                                                                             | Yes      |
+| `username`     | `string` | Wallet user's Farcaster username.                                                                              | Yes      |
+| `bio`          | `string` | Wallet user's bio.                                                                                             | Yes      |
+| `displayName`  | `string` | Wallet user's display name.                                                                                    | Yes      |
+| `pfpUrl`       | `string` | Wallet user's profile photo URL.                                                                               | Yes      |
 
 ## Returns
 
@@ -57,7 +57,7 @@ const params = await walletClient.authenticate({
 | `data.state`       | Status of the sign in request, either `"pending"` or `"complete"` |
 | `data.nonce`       | Random nonce used in the SIWE message.                            |
 | `data.message`     | The generated SIWE message.                                       |
-| `data.signature`   | Hex signature produced by the user's Warpcast wallet.             |
+| `data.signature`   | Hex signature produced by the user's Farcaster client app wallet. |
 | `data.fid`         | User's Farcaster ID.                                              |
 | `data.username`    | User's Farcaster username.                                        |
 | `data.bio`         | User's Farcaster bio.                                             |

--- a/docs/auth-kit/hooks/use-sign-in.md
+++ b/docs/auth-kit/hooks/use-sign-in.md
@@ -89,12 +89,12 @@ function App() {
 | `isError`            | True when an error has occurred.                                                                                                   |
 | `error`              | `AuthClientError` instance.                                                                                                        |
 | `channelToken`       | Connect relay channel token.                                                                                                       |
-| `url`                | Sign in With Farcaster URL to present to the user. Links to Warpcast in v1.                                                        |
+| `url`                | Sign in With Farcaster URL to present to the user. Links to the Farcaster client in v1.                                            |
 | `appClient`          | Underlying `AppClient` instance.                                                                                                   |
 | `data.state`         | Status of the sign in request, either `"pending"` or `"complete"`                                                                  |
 | `data.nonce`         | Random nonce used in the SIWE message. If you don't provide a custom nonce as an argument to the hook, you should read this value. |
 | `data.message`       | The generated SIWE message.                                                                                                        |
-| `data.signature`     | Hex signature produced by the user's Warpcast wallet.                                                                              |
+| `data.signature`     | Hex signature produced by the user's Farcaster client app wallet.                                                                  |
 | `data.fid`           | User's Farcaster ID.                                                                                                               |
 | `data.username`      | User's Farcaster username.                                                                                                         |
 | `data.bio`           | User's Farcaster bio.                                                                                                              |

--- a/docs/developers/frames/getting-started.md
+++ b/docs/developers/frames/getting-started.md
@@ -93,7 +93,7 @@ pnpm run deploy
 ```
 
 Complete the prompts. Once your frame is deployed you can test it end-to-end
-using the [Warpcast Frame Validator](https://warpcast.com/~/developers/frames-legacy).
+using the [Farcaster Client Frame Validator](https://farcaster.xyz/~/developers/frames-legacy).
 
 ::: info
 Make sure to plug the full frame URL in. For Vercel projects this default frame

--- a/docs/developers/frames/resources.md
+++ b/docs/developers/frames/resources.md
@@ -8,7 +8,7 @@ An opinionated collection of popular resources for building Frames.
 
 #### Learning
 
-- [/fc-devs](https://warpcast.com/~/channel/fc-devs) - Farcaster developer channel
+- [/fc-devs](https://farcaster.xyz/~/channel/fc-devs) - Farcaster developer channel
 - [Frames Specification](./spec) - official Frames specification
 - [dTech Zero to Hero Getting Started Guides](https://dtech.vision/farcaster/frames/)
 - [Frames.js Guide](https://framesjs.org/guides/create-frame) - guides from Frames.js
@@ -28,7 +28,7 @@ An opinionated collection of popular resources for building Frames.
 
 #### Developer tools
 
-- [Warpcast Frame Validator](https://warpcast.com/~/developers/frames-legacy) - a debugger for testing frames in Warpcast
+- [Farcaster Client Frame Validator](https://farcaster.xyz/~/developers/frames-legacy) - a debugger for testing frames in the Farcaster client
 - [Neynar](https://docs.neynar.com/docs/how-to-build-farcaster-frames-with-neynar) - infrastructure and tools for frame servers
 - [Neynar Frame Studio](https://neynar.com/nfs) - build no-code Frames
 - [Pinata](https://docs.pinata.cloud/farcaster/frames) - Frame analytics, hub APIs, and more

--- a/docs/developers/frames/spec.md
+++ b/docs/developers/frames/spec.md
@@ -50,7 +50,7 @@ A frame enters Farcaster when a user creates a cast and embeds the frame URL in 
 
 ## Constructing a frame
 
-A frame must include required properties and may contain optional properties. Frames can be validated using the [Frame Validator](https://warpcast.com/~/developers/frames-legacy) tool provided by Warpcast.
+A frame must include required properties and may contain optional properties. Frames can be validated using the [Frame Validator](https://farcaster.com/~/developers/frames-legacy) tool provided by the Farcaster client.
 
 ### Properties
 
@@ -451,20 +451,20 @@ Although it may be possible to validate an Ed25519 signature onchain, a valid si
 
 ## vNext Changelog
 
-| Date    | Change                                                                                                                                                                                          |
-| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 7/10/24 | Frames should include the address that took a wallet action when posting back to target.                                                                                                        |
-| 7/10/24 | Frames can request [EIP-712 signatures](https://www.notion.so/warpcast/Frames-Wallet-Signatures-debe97a82e2643d094d4088f1badd791?pm=c).                                                         |
-| 3/25/24 | Frames can surface [application-level errors](https://warpcast.notion.site/Frames-Errors-ddc965b097d44d9ea03ddf98498597c6?pvs=74) to users.                                                     |
-| 3/8/24  | Frames can request [transactions](https://www.notion.so/warpcast/Frame-Transactions-Public-9d9f9f4f527249519a41bd8d16165f73#c1c3182208ce4ae4a7ffa72129b9795a) from the user's connected wallet. |
-| 2/25/24 | Frames can pass [state](https://www.notion.so/warpcast/Frames-State-Public-f3de69c1d12944e583a37204c98d25d9) to the frame server.                                                               |
-| 2/23/24 | Frames can use HTTP cache headers to refresh their initial image.                                                                                                                               |
-| 2/8/24  | Frames can have [NFT mint buttons](https://warpcast.notion.site/Frames-Mint-action-Public-cea0d2249e3e41dbafb2e9ab23107275) and images with 1:1 aspect ratio.                                   |
-| 2/6/24  | Frames can define [simple links to external pages](https://warpcast.notion.site/Frames-External-Links-Public-60c9900cffae4e2fb1b6aae3d4601c15?pvs=4).                                           |
-| 2/2/24  | Frames can [accept text input](https://warpcast.notion.site/Frames-Text-Input-Public-27c9f0d61903486d89b6d932dd0d6a22).                                                                         |
-| 1/30/24 | Frames [validator](https://warpcast.com/~/developers/frames-legacy) launched.                                                                                                                   |
-| 1/29/24 | Frames support redirecting after the post action.                                                                                                                                               |
-| 1/26/24 | Frames launched.                                                                                                                                                                                |
+| Date    | Change                                                                                                                                                                                           |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 7/10/24 | Frames should include the address that took a wallet action when posting back to target.                                                                                                         |
+| 7/10/24 | Frames can request [EIP-712 signatures](https://www.notion.so/farcaster/Frames-Wallet-Signatures-debe97a82e2643d094d4088f1badd791?pm=c).                                                         |
+| 3/25/24 | Frames can surface [application-level errors](https://farcaster.notion.site/Frames-Errors-ddc965b097d44d9ea03ddf98498597c6?pvs=74) to users.                                                     |
+| 3/8/24  | Frames can request [transactions](https://www.notion.so/farcaster/Frame-Transactions-Public-9d9f9f4f527249519a41bd8d16165f73#c1c3182208ce4ae4a7ffa72129b9795a) from the user's connected wallet. |
+| 2/25/24 | Frames can pass [state](https://www.notion.so/farcaster/Frames-State-Public-f3de69c1d12944e583a37204c98d25d9) to the frame server.                                                               |
+| 2/23/24 | Frames can use HTTP cache headers to refresh their initial image.                                                                                                                                |
+| 2/8/24  | Frames can have [NFT mint buttons](https://farcaster.notion.site/Frames-Mint-action-Public-cea0d2249e3e41dbafb2e9ab23107275) and images with 1:1 aspect ratio.                                   |
+| 2/6/24  | Frames can define [simple links to external pages](https://farcaster.notion.site/Frames-External-Links-Public-60c9900cffae4e2fb1b6aae3d4601c15?pvs=4).                                           |
+| 2/2/24  | Frames can [accept text input](https://farcaster.notion.site/Frames-Text-Input-Public-27c9f0d61903486d89b6d932dd0d6a22).                                                                         |
+| 1/30/24 | Frames [validator](https://farcaster.com/~/developers/frames-legacy) launched.                                                                                                                   |
+| 1/29/24 | Frames support redirecting after the post action.                                                                                                                                                |
+| 1/26/24 | Frames launched.                                                                                                                                                                                 |
 
 ## vNext Proposed Changes
 

--- a/docs/developers/guides/accounts/create-account-key.md
+++ b/docs/developers/guides/accounts/create-account-key.md
@@ -58,7 +58,7 @@ const aliceAccountKey = new ViemLocalEip712Signer(alice as any);
 
 const deadline = BigInt(Math.floor(Date.now() / 1000) + 3600); // Set the signatures' deadline to 1 hour from now
 
-const WARPCAST_RECOVERY_PROXY = '0x00000000FcB080a4D6c39a9354dA9EB9bC104cd7';
+const FARCASTER_RECOVERY_PROXY = '0x00000000FcB080a4D6c39a9354dA9EB9bC104cd7';
 ```
 
 ### 2. Register an app FID
@@ -78,7 +78,7 @@ const { request } = await publicClient.simulateContract({
   address: ID_GATEWAY_ADDRESS,
   abi: idGatewayABI,
   functionName: 'register',
-  args: [WARPCAST_RECOVERY_PROXY, 0n],
+  args: [FARCASTER_RECOVERY_PROXY, 0n],
   value: price,
 });
 await walletClient.writeContract(request);
@@ -239,7 +239,7 @@ console.log('Alice:', alice.address);
  */
 const deadline = BigInt(Math.floor(Date.now() / 1000) + 3600); // Set the signatures' deadline to 1 hour from now
 
-const WARPCAST_RECOVERY_PROXY = '0x00000000FcB080a4D6c39a9354dA9EB9bC104cd7';
+const FARCASTER_RECOVERY_PROXY = '0x00000000FcB080a4D6c39a9354dA9EB9bC104cd7';
 
 /*******************************************************************************
  * IdGateway - register - Register an app FID.
@@ -264,7 +264,7 @@ const { request } = await publicClient.simulateContract({
   address: ID_GATEWAY_ADDRESS,
   abi: idGatewayABI,
   functionName: 'register',
-  args: [WARPCAST_RECOVERY_PROXY, 0n],
+  args: [FARCASTER_RECOVERY_PROXY, 0n],
   value: price,
 });
 await walletClient.writeContract(request);

--- a/docs/developers/guides/accounts/create-account.md
+++ b/docs/developers/guides/accounts/create-account.md
@@ -61,7 +61,7 @@ const aliceAccountKey = new ViemLocalEip712Signer(alice as any);
 
 const deadline = BigInt(Math.floor(Date.now() / 1000) + 3600); // Set the signatures' deadline to 1 hour from now
 
-const WARPCAST_RECOVERY_PROXY = '0x00000000FcB080a4D6c39a9354dA9EB9bC104cd7';
+const FARCASTER_RECOVERY_PROXY = '0x00000000FcB080a4D6c39a9354dA9EB9bC104cd7';
 ```
 
 ### 2. Register an app FID
@@ -81,7 +81,7 @@ const { request } = await publicClient.simulateContract({
   address: ID_GATEWAY_ADDRESS,
   abi: idGatewayABI,
   functionName: 'register',
-  args: [WARPCAST_RECOVERY_PROXY, 0n],
+  args: [FARCASTER_RECOVERY_PROXY, 0n],
   value: price,
 });
 await walletClient.writeContract(request);
@@ -108,7 +108,7 @@ let nonce = await publicClient.readContract({
 
 const registerSignatureResult = await aliceAccountKey.signRegister({
   to: alice.address as `0x${string}`,
-  recovery: WARPCAST_RECOVERY_PROXY,
+  recovery: FARCASTER_RECOVERY_PROXY,
   nonce,
   deadline,
 });
@@ -201,7 +201,7 @@ if (addSignatureResult.isOk()) {
     args: [
       {
         to: alice.address,
-        recovery: WARPCAST_RECOVERY_PROXY,
+        recovery: FARCASTER_RECOVERY_PROXY,
         sig: bytesToHex(registerSignature),
         deadline,
       },
@@ -268,7 +268,7 @@ const aliceAccountKey = new ViemLocalEip712Signer(alice as any);
 
 const deadline = BigInt(Math.floor(Date.now() / 1000) + 3600); // Set the signatures' deadline to 1 hour from now
 
-const WARPCAST_RECOVERY_PROXY = '0x00000000FcB080a4D6c39a9354dA9EB9bC104cd7';
+const FARCASTER_RECOVERY_PROXY = '0x00000000FcB080a4D6c39a9354dA9EB9bC104cd7';
 
 /*******************************************************************************
  * IdGateway - register - Register an app FID.
@@ -293,7 +293,7 @@ const { request } = await publicClient.simulateContract({
   address: ID_GATEWAY_ADDRESS,
   abi: idGatewayABI,
   functionName: 'register',
-  args: [WARPCAST_RECOVERY_PROXY, 0n],
+  args: [FARCASTER_RECOVERY_PROXY, 0n],
   value: price,
 });
 await walletClient.writeContract(request);
@@ -321,7 +321,7 @@ let nonce = await publicClient.readContract({
 
 const registerSignatureResult = await aliceAccountKey.signRegister({
   to: alice.address as `0x${string}`,
-  recovery: WARPCAST_RECOVERY_PROXY,
+  recovery: FARCASTER_RECOVERY_PROXY,
   nonce,
   deadline,
 });
@@ -406,7 +406,7 @@ if (accountKeyResult.isOk()) {
         args: [
           {
             to: alice.address,
-            recovery: WARPCAST_RECOVERY_PROXY,
+            recovery: FARCASTER_RECOVERY_PROXY,
             sig: bytesToHex(registerSignature),
             deadline,
           },

--- a/docs/hubble/migrating.md
+++ b/docs/hubble/migrating.md
@@ -1,4 +1,4 @@
-# Migrating to snapchain 
+# Migrating to snapchain
 
 [Snapchain](https://github.com/farcasterxyz/snapchain) is a more scalable implementation of the Farcaster protocol. In order to interact with snapchain, you can operate your own read node.
 
@@ -19,7 +19,7 @@ Read APIs are fully backwards compatible with hubs so no migration is required. 
 Via http once you have a node running
 
 ```bash
-curl http://locaalhost:3381/v1/info 
+curl http://locaalhost:3381/v1/info
 ```
 
 Via grpc
@@ -42,12 +42,12 @@ In order to write to snapchain, you should run a node and submit directly to it.
 
 - If you're not using the builders from the `hub-nodejs` library, you should make sure to populate `dataBytes` instead of `data` in every message, like so:
 
-    ```ts
-    if (message.dataBytes === undefined) {
-        message.dataBytes = protobufs.MessageData.encode(message.data).finish();
-        message.data = undefined;
-    }
-    ```
+  ```ts
+  if (message.dataBytes === undefined) {
+    message.dataBytes = protobufs.MessageData.encode(message.data).finish();
+    message.data = undefined;
+  }
+  ```
 
 - Some of the error messages returned from `submitMessage` are different in Snapchain than in Hubs.
 - Snapchain submits are best-effort. It's possible that `submitMessage` succeeds but the message is not included into a block. Follow [this issue](https://github.com/farcasterxyz/snapchain/issues/353) on the plan for providing feedback to clients when a message accepted into the mempool is not able to be included in a block.

--- a/docs/hubble/tutorials.md
+++ b/docs/hubble/tutorials.md
@@ -2,6 +2,6 @@
 
 Guides to set up a Hubble instance using various cloud providers.
 
-- [AWS EC2](https://warpcast.notion.site/Set-up-Hubble-on-EC2-Public-23b4e81d8f604ca9bf8b68f4bb086042)
-- [Digital Ocean](https://warpcast.notion.site/Set-up-Hubble-on-DigitalOcean-Public-e38173c487874c91828665e73eac94c1)
+- [AWS EC2](https://farcaster.notion.site/Set-up-Hubble-on-EC2-Public-23b4e81d8f604ca9bf8b68f4bb086042)
+- [Digital Ocean](https://farcaster.notion.site/Set-up-Hubble-on-DigitalOcean-Public-e38173c487874c91828665e73eac94c1)
 - [Google Cloud Platform (GCP)](tutorials/gcp.md)

--- a/docs/hubble/tutorials.md
+++ b/docs/hubble/tutorials.md
@@ -2,6 +2,6 @@
 
 Guides to set up a Hubble instance using various cloud providers.
 
-- [AWS EC2](https://farcaster.notion.site/Set-up-Hubble-on-EC2-Public-23b4e81d8f604ca9bf8b68f4bb086042)
-- [Digital Ocean](https://farcaster.notion.site/Set-up-Hubble-on-DigitalOcean-Public-e38173c487874c91828665e73eac94c1)
+- [AWS EC2](https://warpcast.notion.site/Set-up-Hubble-on-EC2-Public-23b4e81d8f604ca9bf8b68f4bb086042)
+- [Digital Ocean](https://warpcast.notion.site/Set-up-Hubble-on-DigitalOcean-Public-e38173c487874c91828665e73eac94c1)
 - [Google Cloud Platform (GCP)](tutorials/gcp.md)

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -5,7 +5,7 @@ Farcaster is a [sufficiently decentralized](https://www.varunsrinivasan.com/2022
 It is a public social network similar to X and Reddit. Users can create profiles, post "casts" and follow others. They own their accounts and relationships with other users and are free to move between different apps.
 
 :::tip Join Farcaster
-If you're not on Farcaster, get started by [creating your account](https://www.farcaster.xyz/) with the Farcaster client.
+If you're not on Farcaster, get started by [creating your account](https://www.farcaster.xyz/) with the official Farcaster client.
 :::
 
 ## Learn

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -5,7 +5,7 @@ Farcaster is a [sufficiently decentralized](https://www.varunsrinivasan.com/2022
 It is a public social network similar to X and Reddit. Users can create profiles, post "casts" and follow others. They own their accounts and relationships with other users and are free to move between different apps.
 
 :::tip Join Farcaster
-If you're not on Farcaster, get started by [creating your account](https://www.farcaster.xyz/) with Warpcast.
+If you're not on Farcaster, get started by [creating your account](https://www.farcaster.xyz/) with the Farcaster client.
 :::
 
 ## Learn

--- a/docs/learn/what-is-farcaster/accounts.md
+++ b/docs/learn/what-is-farcaster/accounts.md
@@ -8,7 +8,7 @@ A Farcaster account is created by calling the IdGateway contract. It will assign
 
 You'll need to get a username, rent storage and add a key before you can use your account. These steps require many signatures and onchain transactions and can be tedious with a regular Ethereum wallet.
 
-We recommend starting with [Warpcast](https://www.warpcast.com/), a special Farcaster client software which will handle the entire flow for you. It also uses a separate Ethereum account to sign transactions, so you can keep your main Ethereum account secure.
+We recommend starting with the [Farcaster client](https://www.farcaster.xyz/), developed by the Farcaster team which will handle the entire flow for you. It also uses a separate Ethereum account to sign transactions, so you can keep your main Ethereum account secure.
 
 ## Adding account keys
 
@@ -20,7 +20,7 @@ Keys are managed by the KeyRegistry contract. To add a key, you'll need to submi
 
 Users often set up separate wallets for their social apps and it's easy to lose access. Farcaster lets any account specify a recovery address which can be used to recover the account. It can be configured when creating the account or anytime after.
 
-Users can set the recovery address to trusted services like Warpcast or they can manage it themselves using a regular Ethereum wallet.
+Users can set the recovery address to trusted services like the Farcaster client or they can manage it themselves using a regular Ethereum wallet.
 
 ## Resources
 

--- a/docs/learn/what-is-farcaster/accounts.md
+++ b/docs/learn/what-is-farcaster/accounts.md
@@ -8,7 +8,7 @@ A Farcaster account is created by calling the IdGateway contract. It will assign
 
 You'll need to get a username, rent storage and add a key before you can use your account. These steps require many signatures and onchain transactions and can be tedious with a regular Ethereum wallet.
 
-We recommend starting with the [Farcaster client](https://www.farcaster.xyz/), developed by the Farcaster team which will handle the entire flow for you. It also uses a separate Ethereum account to sign transactions, so you can keep your main Ethereum account secure.
+We recommend starting with the [official client](https://www.farcaster.xyz/), developed by the Farcaster team which will handle the entire flow for you. It also uses a separate Ethereum account to sign transactions, so you can keep your main Ethereum account secure.
 
 ## Adding account keys
 
@@ -20,7 +20,7 @@ Keys are managed by the KeyRegistry contract. To add a key, you'll need to submi
 
 Users often set up separate wallets for their social apps and it's easy to lose access. Farcaster lets any account specify a recovery address which can be used to recover the account. It can be configured when creating the account or anytime after.
 
-Users can set the recovery address to trusted services like the Farcaster client or they can manage it themselves using a regular Ethereum wallet.
+Users can set the recovery address to trusted services like the official Farcaster client or they can manage it themselves using a regular Ethereum wallet.
 
 ## Resources
 

--- a/docs/learn/what-is-farcaster/apps.md
+++ b/docs/learn/what-is-farcaster/apps.md
@@ -1,6 +1,6 @@
 # Apps
 
-Using Farcaster requires an Ethereum wallet to register your account and UI to browse the network. If you are new, we recommend starting with the Farcaster client on [iOS](https://apps.apple.com/us/app/warpcast/id1600555445) or [Android](https://play.google.com/store/apps/details?id=com.farcaster.mobile&hl=en_US&gl=US)
+Using Farcaster requires an Ethereum wallet to register your account and UI to browse the network. If you are new, we recommend starting with the official Farcaster client on [iOS](https://apps.apple.com/us/app/warpcast/id1600555445) or [Android](https://play.google.com/store/apps/details?id=com.farcaster.mobile&hl=en_US&gl=US)
 
 There are two kinds of apps:
 

--- a/docs/learn/what-is-farcaster/apps.md
+++ b/docs/learn/what-is-farcaster/apps.md
@@ -1,6 +1,6 @@
 # Apps
 
-Using Farcaster requires an Ethereum wallet to register your account and UI to browse the network. If you are new, we recommend starting with Warpcast on [iOS](https://apps.apple.com/us/app/warpcast/id1600555445) or [Android](https://play.google.com/store/apps/details?id=com.farcaster.mobile&hl=en_US&gl=US)
+Using Farcaster requires an Ethereum wallet to register your account and UI to browse the network. If you are new, we recommend starting with the Farcaster client on [iOS](https://apps.apple.com/us/app/warpcast/id1600555445) or [Android](https://play.google.com/store/apps/details?id=com.farcaster.mobile&hl=en_US&gl=US)
 
 There are two kinds of apps:
 
@@ -13,9 +13,9 @@ Users must install a wallet app to get started with Farcaster. They can take onc
 
 A wallet app controls the Ethereum address that owns the account. It has control over the account and can take any action on your behalf, so only use a wallet app that you trust.
 
-### Warpcast
+### Farcaster client
 
-Warpcast is a wallet app developed by the Farcaster team. It has a web and mobile app, though signing up is only available on mobile.
+The Farcaster client is a wallet app developed by the Farcaster team. It has a web and mobile app, though signing up is only available on mobile.
 
 - Download: [iOS](https://apps.apple.com/us/app/warpcast/id1600555445), [Android](https://play.google.com/store/apps/details?id=com.farcaster.mobile&hl=en_US&gl=US)
 

--- a/docs/learn/what-is-farcaster/channels.md
+++ b/docs/learn/what-is-farcaster/channels.md
@@ -5,35 +5,35 @@ A channel is a public space for your community to have conversations around a to
 Creating a channel starts a new feed for your community. People can join, cast and find other interesting people. It sparks conversations that wouldn’t otherwise happen on the home feed.
 
 :::warning Experimental Feature
-Channels are being prototyped in Warpcast and not fully supported by the Farcaster protocol. They may be ported to the protocol in the future if the feature is deemed successful or they may be removed entirely.
+Channels are being prototyped in the Farcaster client and not fully supported by the Farcaster protocol. They may be ported to the protocol in the future if the feature is deemed successful or they may be removed entirely.
 :::
 
 ## Hosting Channels
 
-Anyone can create a channel host by paying a fee in Warpcast and choosing a channel name. The name must be under 16 characters and can only contain lowercase alphabets and numbers. A channel's creator is called a host and may invite other co-hosts to operate the channel. Hosts have special privileges like:
+Anyone can create a channel host by paying a fee in the Farcaster client and choosing a channel name. The name must be under 16 characters and can only contain lowercase alphabets and numbers. A channel's creator is called a host and may invite other co-hosts to operate the channel. Hosts have special privileges like:
 
 1. Defining “channel norms" which everyone must agree to when joining.
 2. Pinning or hiding casts in a channel.
 3. Blocking other users from casting in their channel.
 4. Setting a channel picture, description and other metadata.
 
-Channel metadata is not part of the protocol and stored in Warpcast while channels are in the experimental stage.
+Channel metadata is not part of the protocol and stored in the Farcaster client while channels are in the experimental stage.
 
 ## Casting in Channels
 
-Anyone can post into a channel by using Warpcast and selecting the channel when creating the cast. Warpcast automatically sets the cast's `parentUrl` to `https://farcaster.xyz/~/channel/<name>`. A cast is considered "in a channel" if it's parentUrl is the channel URI or another cast which is "in a channel".
+Anyone can post into a channel by using the Farcaster client and selecting the channel when creating the cast. The client automatically sets the cast's `parentUrl` to `https://farcaster.xyz/~/channel/<name>`. A cast is considered "in a channel" if it's parentUrl is the channel URI or another cast which is "in a channel".
 
 Channel casts are part of the protocol and stored on hubs. Using a replicator, you can fetch all casts in a channel by filtering the `parentUrl` field for the channel's FIP-2 URL.
 
 ## Following Channels
 
-Anyone can follow a channel just like a user. A user will see casts from a followed channel in their home feed when using Warpcast.
+Anyone can follow a channel just like a user. A user will see casts from a followed channel in their home feed when using the Farcaster client.
 
-Channel follows are not part of the protocol and are stored in Warpcast while channels are in the experimental stage.
+Channel follows are not part of the protocol and are stored in the Farcaster client while channels are in the experimental stage.
 
 ## Cast Visibility
 
-If a user casts in a channel, Warpcast will:
+If a user casts in a channel, the Farcaster client will:
 
 1. Always send the casts to the home feeds of any user who follows the channel.
 2. Usually send the casts to the home feeds of any user who follows the author.
@@ -42,11 +42,11 @@ The determination for (2) is made based on the user's preferences, channel conte
 
 ## Usage Policy
 
-Warpcast may remove your channel and will NOT refund your warps if:
+The Farcaster client may remove your channel and will NOT refund your warps if:
 
 1. Your profile or channel impersonates someone.
 2. You squat a channel without using it.
-3. You violate Warpcast's terms and conditions or app store rules.
+3. You violate the Farcaster client's terms and conditions or app store rules.
 
 ## FAQ
 
@@ -62,7 +62,7 @@ The fee discourages people from squatting short names and not using the channels
 
 Starting a channel also helps grow your audience:
 
-1. Warpcast will send your followers a notification about your channel.
+1. The Farcaster client will send your followers a notification about your channel.
 2. Your channel will be promoted to users who follow similar channels.
 3. Users who follow your channel will see channel casts in their home feed.
 
@@ -70,4 +70,4 @@ Starting a channel also helps grow your audience:
 
 ### APIs
 
-- [Warpcast Channel APIs](../../reference/client/api.md) - fetch a list of all known channels
+- [Farcaster Client Channel APIs](../../reference/client/api.md) - fetch a list of all known channels

--- a/docs/learn/what-is-farcaster/channels.md
+++ b/docs/learn/what-is-farcaster/channels.md
@@ -33,7 +33,7 @@ Channel follows are not part of the protocol and are stored in the Farcaster cli
 
 ## Cast Visibility
 
-If a user casts in a channel, the Farcaster client will:
+If a user casts in a channel, Farcaster will:
 
 1. Always send the casts to the home feeds of any user who follows the channel.
 2. Usually send the casts to the home feeds of any user who follows the author.

--- a/docs/learn/what-is-farcaster/usernames.md
+++ b/docs/learn/what-is-farcaster/usernames.md
@@ -17,7 +17,7 @@ An account can choose between two kinds of usernames:
 - **Offchain ENS Names**: free and controlled by farcaster. (e.g. @alice)
 - **Onchain ENS Names**: costs money and controlled by your wallet. (e.g. @alice.eth)
 
-Choose an offchain ENS name if you want to get started quickly and don't have an onchain ENS name. An account can always upgrade to an onchain name later. It's recommended to use an app like Warpcast to set this up for you.
+Choose an offchain ENS name if you want to get started quickly and don't have an onchain ENS name. An account can always upgrade to an onchain name later. It's recommended to use an app like the official Farcaster client to set this up for you.
 
 ![Usernames](/assets/usernames.png)
 

--- a/docs/reference/client/direct-casts.md
+++ b/docs/reference/client/direct-casts.md
@@ -1,10 +1,10 @@
 # Direct Casts
 
-This page documents public APIs provided by Warpcast for direct casts. Direct casts are currently not part of the protocol. There are plans to add direct casts to the protocol later this year.
+This page documents public APIs provided by the Farcaster client for direct casts. Direct casts are currently not part of the protocol. There are plans to add direct casts to the protocol later this year.
 
 #### Send / write API for direct casts
 
-- [Send direct casts via API](https://www.notion.so/warpcast/Public-Programmable-DCs-v1-50d9d99e34ac4d10add55bd26a91804f)
+- [Send direct casts via API](https://www.notion.so/farcaster/Public-Programmable-DCs-v1-50d9d99e34ac4d10add55bd26a91804f)
 - The above link also provides information on how to obtain direct cast API keys
 
 #### Direct cast intents
@@ -12,7 +12,7 @@ This page documents public APIs provided by Warpcast for direct casts. Direct ca
 Intents enable developers to direct authenticated users to a pre-filled direct cast composer via a URL.
 
 ```bash
-https://warpcast.com/~/inbox/create/[fid]?text=[message]
+https://farcaster.xyz/~/inbox/create/[fid]?text=[message]
 
-https://warpcast.com/~/inbox/create/1?text=gm
+https://farcaster.xyz/~/inbox/create/1?text=gm
 ```

--- a/docs/reference/client/direct-casts.md
+++ b/docs/reference/client/direct-casts.md
@@ -1,10 +1,10 @@
 # Direct Casts
 
-This page documents public APIs provided by the Farcaster client for direct casts. Direct casts are currently not part of the protocol. There are plans to add direct casts to the protocol later this year.
+This page documents public APIs provided by the official Farcaster client for direct casts. Direct casts are currently not part of the protocol. There are plans to add direct casts to the protocol later this year.
 
 #### Send / write API for direct casts
 
-- [Send direct casts via API](https://www.notion.so/farcaster/Public-Programmable-DCs-v1-50d9d99e34ac4d10add55bd26a91804f)
+- [Send direct casts via API](https://www.notion.so/warpcast/Public-Programmable-DCs-v1-50d9d99e34ac4d10add55bd26a91804f)
 - The above link also provides information on how to obtain direct cast API keys
 
 #### Direct cast intents

--- a/docs/reference/client/embeds.md
+++ b/docs/reference/client/embeds.md
@@ -1,11 +1,11 @@
-# Warpcast Embeds Reference
+# Farcaster Client Embeds Reference
 
-Warpcast follows the [Open Graph protocol](https://ogp.me) when rendering rich previews for URL embeds.
+The Farcaster client follows the [Open Graph protocol](https://ogp.me) when rendering rich previews for URL embeds.
 
-Developers can reset existing embed caches on Warpcast at https://warpcast.com/~/developers/embeds.
+Developers can reset existing embed caches on the Farcaster client at https://farcaster.xyz/~/developers/embeds.
 
 #### Additional details
 
 - Resetting an embed cache, does not reset Open Graph image caches. If you are experiencing a stale image on your Open Graph, change the image file path served as the `og:image`.
-- Developers have to be logged in to Warpcast to access this page.
+- Developers have to be logged in to the Farcaster client to access this page.
 - To render rich previews of NFTs, follow the [Farcaster Frames spec](/developers/frames/spec).

--- a/docs/reference/client/signer-requests.md
+++ b/docs/reference/client/signer-requests.md
@@ -8,10 +8,10 @@ If your application wants to write data to Farcaster on behalf of a user, the ap
 
 - a registered FID
 
-### 1. An authenticated user clicks "Connect with Warpcast" in your app
+### 1. An authenticated user clicks "Connect with Farcaster" in your app
 
 Once your app can identify and authenticate a user you can present them with
-the option to connect with Warpcast.
+the option to connect with Farcaster.
 
 ### 2. Generate a new Ed25519 key pair for the user and SignedKeyRequest signature
 
@@ -83,16 +83,16 @@ This value controls how long the Signed Key Request signature is valid for. It
 is a Unix timestamp in second (note: JavaScript uses millisecond). We recommend
 setting this to 24 hours.
 
-### 3. App uses the public key + SignedKeyRequest signature to initiate a Signed Key Request using the Warpcast API
+### 3. App uses the public key + SignedKeyRequest signature to initiate a Signed Key Request using the Farcaster client API
 
-The app calls the Warpcast backend which returns a deeplink and a session token that can be used to check the status of the request.
+The app calls the Farcaster client backend which returns a deeplink and a session token that can be used to check the status of the request.
 
 ```ts
 /*** Creating a Signed Key Request ***/
 
-const warpcastApi = 'https://api.warpcast.com';
+const farcasterApi = 'https://api.farcaster.xyz';
 const { token, deeplinkUrl } = await axios
-  .post(`${warpcastApi}/v2/signed-key-requests`, {
+  .post(`${farcasterApi}/v2/signed-key-requests`, {
     key: publicKey,
     requestFid: fid,
     signature,
@@ -119,10 +119,8 @@ You can sponsor the onchain fees for the user. See [Sponsoring a signer](#sponso
 
 ### 4. Application presents the deep link from the response to the user
 
-The app presents the deeplink which will prompt the user to open the Warpcast
-app and authorize the signer request (screenshots at the bottom). The app
-should direct the user to open the link on their mobile device they have
-Warpcast installed on:
+The app presents the deeplink which will prompt the user to open the Farcaster client app and authorize the signer request (screenshots at the bottom). The app should direct the user to open the link on their mobile device they have
+the Farcaster client installed on:
 
 1. when on mobile, trigger the deeplink directly
 2. when on web, display the deeplink as a QR code to scan
@@ -150,7 +148,7 @@ const poll = async (token: string) => {
 
     console.log('polling signed key request');
     const signedKeyRequest = await axios
-      .get(`${warpcastApi}/v2/signed-key-request`, {
+      .get(`${farcasterApi}/v2/signed-key-request`, {
         params: {
           token,
         },
@@ -176,9 +174,9 @@ const poll = async (token: string) => {
 poll(token);
 ````
 
-### 6. User opens the link and completes Signer Request flow in Warpcast
+### 6. User opens the link and completes Signer Request flow in the Farcaster client app
 
-When the user approves the request in Warpcast, an onchain transaction will be
+When the user approves the request in the client app, an onchain transaction will be
 made that grants write permissions to that signer. Once that completes your app
 should indicate success and can being writing messages using the newly added key.
 
@@ -234,9 +232,9 @@ const SIGNED_KEY_REQUEST_TYPE = [
 
   /*** Creating a Signed Key Request ***/
 
-  const warpcastApi = 'https://api.warpcast.com';
+  const farcasterApi = 'https://api.farcaster.xyz';
   const { token, deeplinkUrl } = await axios
-    .post(`${warpcastApi}/v2/signed-key-requests`, {
+    .post(`${farcasterApi}/v2/signed-key-requests`, {
       key,
       requestFid: appFid,
       signature,
@@ -255,7 +253,7 @@ const SIGNED_KEY_REQUEST_TYPE = [
 
       console.log('polling signed key request');
       const signedKeyRequest = await axios
-        .get(`${warpcastApi}/v2/signed-key-request`, {
+        .get(`${farcasterApi}/v2/signed-key-request`, {
           params: {
             token,
           },
@@ -377,7 +375,7 @@ Get the state of a signed key requests.
 ## Sponsoring a signer
 
 An application can sponsor a signer so that the user doesn’t need to pay. The
-application must be signed up on Warpcast and have a warps ≥ 100.
+application must be signed up on the Farcaster client app and have a warps ≥ 100.
 
 When generating a signed key request an application can indicate it should be
 sponsored by including an additional `sponsorship` field in the request body.
@@ -410,4 +408,4 @@ const sponsorSignature = sponsoringAccount.signMessage({
 });
 ```
 
-When the user opens the signed key request in Warpcast they will the onchain fees have been sponsored by your application.
+When the user opens the signed key request in the Farcaster client they will the onchain fees have been sponsored by your application.

--- a/docs/reference/client/signer-requests.md
+++ b/docs/reference/client/signer-requests.md
@@ -90,9 +90,9 @@ The app calls the Farcaster client backend which returns a deeplink and a sessio
 ```ts
 /*** Creating a Signed Key Request ***/
 
-const farcasterApi = 'https://api.farcaster.xyz';
+const farcasterClientApi = 'https://api.farcaster.xyz';
 const { token, deeplinkUrl } = await axios
-  .post(`${farcasterApi}/v2/signed-key-requests`, {
+  .post(`${farcasterClientApi}/v2/signed-key-requests`, {
     key: publicKey,
     requestFid: fid,
     signature,
@@ -147,7 +147,7 @@ const poll = async (token: string) => {
 
     console.log('polling signed key request');
     const signedKeyRequest = await axios
-      .get(`${farcasterApi}/v2/signed-key-request`, {
+      .get(`${farcasterClientApi}/v2/signed-key-request`, {
         params: {
           token,
         },
@@ -231,9 +231,9 @@ const SIGNED_KEY_REQUEST_TYPE = [
 
   /*** Creating a Signed Key Request ***/
 
-  const farcasterApi = 'https://api.farcaster.xyz';
+  const farcasterClientApi = 'https://api.farcaster.xyz';
   const { token, deeplinkUrl } = await axios
-    .post(`${farcasterApi}/v2/signed-key-requests`, {
+    .post(`${farcasterClientApi}/v2/signed-key-requests`, {
       key,
       requestFid: appFid,
       signature,
@@ -252,7 +252,7 @@ const SIGNED_KEY_REQUEST_TYPE = [
 
       console.log('polling signed key request');
       const signedKeyRequest = await axios
-        .get(`${farcasterApi}/v2/signed-key-request`, {
+        .get(`${farcasterClientApi}/v2/signed-key-request`, {
           params: {
             token,
           },

--- a/docs/reference/client/signer-requests.md
+++ b/docs/reference/client/signer-requests.md
@@ -119,8 +119,7 @@ You can sponsor the onchain fees for the user. See [Sponsoring a signer](#sponso
 
 ### 4. Application presents the deep link from the response to the user
 
-The app presents the deeplink which will prompt the user to open the Farcaster client app and authorize the signer request (screenshots at the bottom). The app should direct the user to open the link on their mobile device they have
-the Farcaster client installed on:
+The app presents the deeplink which will prompt the user to open the Farcaster client app and authorize the signer request (screenshots at the bottom). The app should direct the user to open the link on their mobile device they have the Farcaster client installed on:
 
 1. when on mobile, trigger the deeplink directly
 2. when on web, display the deeplink as a QR code to scan

--- a/docs/reference/client/videos.md
+++ b/docs/reference/client/videos.md
@@ -1,8 +1,8 @@
-# How to have your video displayed on Warpcast
+# How to have your video displayed on the Farcaster client
 
 1. Ensure you serve your video as a streamable `.m3u8` file. This ensures clients only download what they need when viewing, and nothing more, providing a high performance experience.
 
-2. Make sure that `.m3u8` manifest exposes the resolution(s) for your video. Warpcast uses this to determine the correct aspect ratio when rendering. A manifest file with resolution data looks something like:
+2. Make sure that `.m3u8` manifest exposes the resolution(s) for your video. The Farcaster client uses this to determine the correct aspect ratio when rendering. A manifest file with resolution data looks something like:
 
 ```
 #EXTM3U
@@ -14,8 +14,8 @@
 720p/video.m3u8
 ```
 
-3. Ensure that at cast publish time the `.m3u8` file is available. Warpcast checks once and if there is no valid data, the cast will show no video.
+3. Ensure that at cast publish time the `.m3u8` file is available. The Farcaster client checks once and if there is no valid data, the cast will show no video.
 
 4. Have the same URL when changed from ending in `/my-video.m3u8` to `/thumbnail.jpg` with a preview/thumbnail image to render before the user has interacted with the video.
 
-5. Reach out to the Warpcast team and ask for us to enable videos for your domain. Tell us the format of your video URLs and we’ll configure our scrapers to display them correctly in the feed. Please make sure to complete all these steps above before reaching out for allowlisting. [Ping @gt on Warpcast](https://warpcast.com/~/inbox/create/302?text=Completed%20video%20setup).
+5. Reach out to the Farcaster team and ask for us to enable videos for your domain. Tell us the format of your video URLs and we’ll configure our scrapers to display them correctly in the feed. Please make sure to complete all these steps above before reaching out for allowlisting. [Ping @gt on Farcaster](https://farcaster.xyz/~/inbox/create/302?text=Completed%20video%20setup).


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating references from `Warpcast` to the `Farcaster client` throughout the documentation and codebase, ensuring consistency in naming and terminology.

### Detailed summary
- Updated references to `Warpcast` with `Farcaster client` in multiple documentation files.
- Changed URLs to reflect the official `Farcaster` domain.
- Clarified descriptions regarding the use of the `Farcaster client` for various functionalities.
- Altered variable names from `WARPCAST_RECOVERY_PROXY` to `FARCASTER_RECOVERY_PROXY` in code files.
- Adjusted instructions and examples to align with the new naming conventions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->