### PR TITLE
Rename Warpcast section in sidebar

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -504,7 +504,7 @@ export default defineConfig({
           items: [{ text: 'Specification', link: '/reference/actions/spec' }],
         },
         {
-          text: 'Warpcast',
+          text: 'Farcaster Client',
           items: [
             { text: 'APIs', link: '/reference/client/api' },
             {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the documentation configuration for the `Warpcast` entry, changing it to `Farcaster Client` to reflect a new naming convention.

### Detailed summary
- Updated the `text` property from `'Warpcast'` to `'Farcaster Client'` in `docs/.vitepress/config.mts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->