### PR TITLE
Fix dead links in learn section

### DIFF
--- a/docs/learn/what-is-farcaster/channels.md
+++ b/docs/learn/what-is-farcaster/channels.md
@@ -70,4 +70,4 @@ Starting a channel also helps grow your audience:
 
 ### APIs
 
-- [Farcaster Client Channel APIs](../../reference/client/api.md) - fetch a list of all known channels
+- [Farcaster Client Channel APIs](../../reference/warpcast/api.md) - fetch a list of all known channels


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the link to the `Farcaster Client Channel APIs` documentation, changing the path from `../../reference/client/api.md` to `../../reference/warpcast/api.md`.

### Detailed summary
- Updated the documentation link for `Farcaster Client Channel APIs` from `../../reference/client/api.md` to `../../reference/warpcast/api.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->