### PR TITLE
Added important note about optimism for auth addresses

### DIFF
--- a/docs/auth-kit/client/app/verify-sign-in-message.md
+++ b/docs/auth-kit/client/app/verify-sign-in-message.md
@@ -5,6 +5,21 @@ Verify a Sign In With Farcaster message. Your app should call this function and 
 Returns the parsed Sign in With Farcaster message, the user's fid, and whether the verification succeeded.
 
 ```ts
+import { createAppClient, viemConnector } from "@farcaster/auth-client"
+
+const appClient = createAppClient({
+  relay: "https://relay.farcaster.xyz",
+  ethereum: viemConnector({
+    // to handle verifying of Auth Addresses, rpc URLs must be Optimism only! 
+    rpcUrls: [ 
+      "https://mainnet.optimism.io",
+      "https://1rpc.io/op",
+      "https://optimism-rpc.publicnode.com",
+      "https://optimism.drpc.org",
+    ],
+  })
+})
+
 const { data, success, fid } = await appClient.verifySignInMessage({
   nonce: 'abcd1234',
   domain: 'example.com',


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f3188be9-7b6f-4c7a-ab04-cb92e3f2dacd)

I was banging my head on my desk for hours figuring out why my auth address method was NOT working, only to learn that the RPC urls MUST BE OPTIMISM. 

This was no where mentioned in the docs, so thought I help everyone out