### PR TITLE
fix: Link to FIPs github discussions instead of duplicating the list

### DIFF
--- a/docs/learn/contributing/fips.md
+++ b/docs/learn/contributing/fips.md
@@ -9,23 +9,7 @@ and [Python's PEPs](https://peps.python.org/pep-0001/). Anyone can write an FIP 
 3. An implementation, like adding a new protocol feature
 
 Read more about FIP's
-in [FIP-0: A proposal for making proposals](https://github.com/farcasterxyz/protocol/discussions/82). A list of
-finalized proposals can be found below. Proposals are made and ratified on
-the [discussions board](https://github.com/farcasterxyz/protocol/discussions/categories/fip-stage-4-finalized).
+in [FIP-0: A proposal for making proposals](https://github.com/farcasterxyz/protocol/discussions/82). Proposals are made and ratified on
+the [discussions board](https://github.com/farcasterxyz/protocol/discussions/).
 
-| FIP | Title                                                                                                   | Authors                                  |
-| --- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| 0   | [A proposal for making proposals](https://github.com/farcasterxyz/protocol/discussions/82)              | @v                                       |
-| 1   | [Canonical URIs](https://github.com/farcasterxyz/protocol/discussions/72)                               | @pfh, @v                                 |
-| 2   | [Flexible targets for messages](https://github.com/farcasterxyz/protocol/discussions/71)                | @pfh                                     |
-| 3   | [Links](https://github.com/farcasterxyz/protocol/discussions/85)                                        | @cassie, @v                              |
-| 4   | [ENS Usernames](https://github.com/farcasterxyz/protocol/discussions/90)                                | @horsefacts, @sanjay, @sds, @v           |
-| 5   | [Instant Recovery](https://github.com/farcasterxyz/protocol/discussions/100)                            | @v                                       |
-| 6   | [Flexible Storage](https://github.com/farcasterxyz/protocol/discussions/98)                             | @cassie, @horsefacts, @v                 |
-| 7   | [Onchain Signers](https://github.com/farcasterxyz/protocol/discussions/103)                             | @horsefacts, @sanjay, @v                 |
-| 8   | [Verifications for Contract Wallets](https://github.com/farcasterxyz/protocol/discussions/109)          | @horsefacts, @sanjay, @eulerlagrange.eth |
-| 9   | [Globally Unique Verifications](https://github.com/farcasterxyz/protocol/discussions/114)               | @sanjay, @v                              |
-| 10  | [Gateways](https://github.com/farcasterxyz/protocol/discussions/133)                                    | @horsefacts, @sanjay, @v                 |
-| 11  | [Sign in with Farcaster](https://github.com/farcasterxyz/protocol/discussions/110)                      | @deodad, @horsefacts, @sanjay, @v        |
-| 12  | [Pricing schedule for flexible storage](https://github.com/farcasterxyz/protocol/discussions/126)       | @v                                       |
-| 13  | [Canonical serialization for hashing messages](https://github.com/farcasterxyz/protocol/discussions/87) | @sanjay, @adityapk                       |
+A list of finalized FIPs can be found [here](https://github.com/farcasterxyz/protocol/discussions/categories/fip-stage-4-finalized).


### PR DESCRIPTION
FIPs list was getting out of date. Just link to the discussion board for latest view

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation in `fips.md` to improve clarity and accuracy regarding finalized FIPs. It modifies the text to better direct readers to relevant links and removes a table that listed FIPs.

### Detailed summary
- Removed the table listing finalized FIPs and their details.
- Updated text to clarify where to find finalized FIPs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->