### PR TITLE
fix: Add redirects for missing Hub/Hubble documentation URLs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -95,6 +95,51 @@
       "source": "/reference/frames/spec",
       "destination": "https://miniapps.farcaster.xyz/docs/specification",
       "permanent": true
+    },
+    {
+      "source": "/reference/hubble/architecture",
+      "destination": "https://snapchain.farcaster.xyz/whitepaper",
+      "permanent": true
+    },
+    {
+      "source": "/reference/hubble/",
+      "destination": "https://snapchain.farcaster.xyz/",
+      "permanent": true
+    },
+    {
+      "source": "/reference/hubble",
+      "destination": "https://snapchain.farcaster.xyz/",
+      "permanent": true
+    },
+    {
+      "source": "/reference/hub/architecture",
+      "destination": "https://snapchain.farcaster.xyz/whitepaper",
+      "permanent": true
+    },
+    {
+      "source": "/reference/hub/",
+      "destination": "https://snapchain.farcaster.xyz/",
+      "permanent": true
+    },
+    {
+      "source": "/reference/hub",
+      "destination": "https://snapchain.farcaster.xyz/",
+      "permanent": true
+    },
+    {
+      "source": "/hubble/architecture",
+      "destination": "https://snapchain.farcaster.xyz/whitepaper",
+      "permanent": true
+    },
+    {
+      "source": "/hubble/",
+      "destination": "https://snapchain.farcaster.xyz/",
+      "permanent": true
+    },
+    {
+      "source": "/hubble",
+      "destination": "https://snapchain.farcaster.xyz/",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
- Add redirects for /reference/hubble/* paths to snapchain.farcaster.xyz
- Add redirects for /reference/hub/* paths to snapchain.farcaster.xyz
- Add redirects for /hubble/* paths to snapchain.farcaster.xyz
- Architecture pages redirect to snapchain whitepaper
- General pages redirect to snapchain homepage

Fixes 404 errors where Google search results show indexed pages that no longer exist due to Hub documentation being moved to external Snapchain site.

Added comprehensive redirects in `vercel.json` to route old Hub/Hubble documentation URLs to the appropriate Snapchain documentation:

- **Architecture pages** → `https://snapchain.farcaster.xyz/whitepaper`
- **General Hub/Hubble pages** → `https://snapchain.farcaster.xyz/`

## Testing
These redirects will work once deployed to Vercel (they don't function in local development).